### PR TITLE
Update lexer.h to follow the convention JUCC_LOCALNAMESPACE_FILENAME_H

### DIFF
--- a/src/include/lexer/lexer.h
+++ b/src/include/lexer/lexer.h
@@ -1,5 +1,5 @@
-#ifndef JUCC_LEXER_H
-#define JUCC_LEXER_H
+#ifndef JUCC_LEXER_LEXER_H
+#define JUCC_LEXER_LEXER_H
 
 #include <cctype>
 #include <cstdio>


### PR DESCRIPTION
This pull request closes #5 
The header guards (#ifndef and #define) have been updated to follow the convention JUCC_LOCALNAMESPACE_FILENAME_H