### PR TITLE
Add: First and Follow

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,7 +12,7 @@ coverage:
         threshold: 5%
     patch:
       default:
-        target: 80%
+        target: 90%
 
 parsers:
   gcov:

--- a/src/grammar/grammar.cpp
+++ b/src/grammar/grammar.cpp
@@ -1,10 +1,29 @@
 #include "grammar/grammar.h"
 
+#include <algorithm>
 #include <sstream>
 #include <unordered_map>
 #include <unordered_set>
 
 namespace jucc::grammar {
+
+bool SearchParent(const grammar::Productions &productions, const std::string &parent) {
+  return std::any_of(productions.begin(), productions.end(),
+                     [&](const grammar::Production &prod) { return prod.GetParent() == parent; });
+}
+
+grammar::Rules GetRulesForParent(const grammar::Productions &productions, const std::string &parent) {
+  grammar::Rules rules;
+  for (const auto &production : productions) {
+    if (production.GetParent() == parent) {
+      for (const auto &rule : production.GetRules()) {
+        rules.push_back(rule);
+      }
+      break;
+    }
+  }
+  return rules;
+}
 
 Parser::Parser(const char *filepath) { file_ = std::ifstream(filepath); }
 

--- a/src/grammar/grammar.cpp
+++ b/src/grammar/grammar.cpp
@@ -19,9 +19,11 @@ grammar::Rules GetRulesForParent(const grammar::Productions &productions, const 
       for (const auto &rule : production.GetRules()) {
         rules.push_back(rule);
       }
+
       break;
     }
   }
+
   return rules;
 }
 

--- a/src/grammar/grammar.cpp
+++ b/src/grammar/grammar.cpp
@@ -7,24 +7,18 @@
 
 namespace jucc::grammar {
 
-bool SearchParent(const grammar::Productions &productions, const std::string &parent) {
+bool HasParent(const grammar::Productions &productions, const std::string &parent) {
   return std::any_of(productions.begin(), productions.end(),
                      [&](const grammar::Production &prod) { return prod.GetParent() == parent; });
 }
 
 grammar::Rules GetRulesForParent(const grammar::Productions &productions, const std::string &parent) {
-  grammar::Rules rules;
   for (const auto &production : productions) {
     if (production.GetParent() == parent) {
-      for (const auto &rule : production.GetRules()) {
-        rules.push_back(rule);
-      }
-
-      break;
+      return production.GetRules();
     }
   }
-
-  return rules;
+  return grammar::Rules();
 }
 
 Parser::Parser(const char *filepath) { file_ = std::ifstream(filepath); }

--- a/src/include/grammar/grammar.h
+++ b/src/include/grammar/grammar.h
@@ -5,6 +5,8 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <unordered_map>
+
 
 namespace jucc {
 namespace grammar {

--- a/src/include/grammar/grammar.h
+++ b/src/include/grammar/grammar.h
@@ -65,7 +65,7 @@ using Productions = std::vector<Production>;
  * utility function
  * @return if parent symbol is present in productions
  */
-bool SearchParent(const grammar::Productions & /*productions*/, const std::string & /*parent*/);
+bool HasParent(const grammar::Productions & /*productions*/, const std::string & /*parent*/);
 
 /**
  * Given a parent finds all rules for it in the set of productions

--- a/src/include/grammar/grammar.h
+++ b/src/include/grammar/grammar.h
@@ -5,8 +5,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-#include <unordered_map>
-
 
 namespace jucc {
 namespace grammar {
@@ -61,6 +59,19 @@ class Production {
 };
 
 using Productions = std::vector<Production>;
+
+/**
+ * Search if a production exists for a given parent
+ * utility function
+ * @return if parent symbol is present in productions
+ */
+bool SearchParent(const grammar::Productions & /*productions*/, const std::string & /*parent*/);
+
+/**
+ * Given a parent finds all rules for it in the set of productions
+ * @returns a vector of rules for the given parent
+ */
+Rules GetRulesForParent(const grammar::Productions & /*productions*/, const std::string & /*parent*/);
 
 class Parser {
   std::ifstream file_;

--- a/src/include/utils/first_follow.h
+++ b/src/include/utils/first_follow.h
@@ -17,7 +17,7 @@ const char STRING_ENDMARKER[] = "$";
  * For each terminal and non terminal in the grammar compute if symbol is / derives to nullable
  * Terminals except EPSILON are defaulted to non nullable
  * @returns an unordered_map keyed by each symbol in the grammar of booleans
- * true if symbol is nullable, false otherwise
+ * true if symbol is nullable, false otherwise.
  */
 std::unordered_map<std::string, bool> CalcNullables(const grammar::Productions & /*augmented_grammar*/);
 
@@ -26,14 +26,14 @@ using SymbolsMap = std::unordered_map<std::string, std::vector<std::string>>;
 /**
  * For each non terminal in given set of productions computes Firsts, and in case of terminals
  * it returns the same.
- * @returns an unordered_map keyed by non terminals in the grammar of a vector of terminals
+ * @returns an unordered_map keyed by the each symbol in the grammar of a vector of terminals.
  */
 SymbolsMap CalcFirsts(const grammar::Productions & /*augmented_grammar*/,
                       const std::unordered_map<std::string, bool> & /*nullables*/);
 
 /**
  * For each non terminal in given set of productions computes Follows
- * @returns an unordered_map keyed by non terminals in the grammar of a vector of terminals
+ * @returns an unordered_map keyed by non terminals in the grammar of a vector of terminals.
  */
 SymbolsMap CalcFollows(const grammar::Productions & /*augmented_grammar*/, const SymbolsMap & /*firsts*/,
                        const std::unordered_map<std::string, bool> & /*nullables*/,

--- a/src/include/utils/first_follow.h
+++ b/src/include/utils/first_follow.h
@@ -24,7 +24,8 @@ std::unordered_map<std::string, bool> CalcNullables(const grammar::Productions &
 using SymbolsMap = std::unordered_map<std::string, std::vector<std::string>>;
 
 /**
- * For each non terminal in given set of productions computes Firsts
+ * For each non terminal in given set of productions computes Firsts, and in case of terminals
+ * it returns the same.
  * @returns an unordered_map keyed by non terminals in the grammar of a vector of terminals
  */
 SymbolsMap CalcFirsts(const grammar::Productions & /*augmented_grammar*/,

--- a/src/include/utils/first_follow.h
+++ b/src/include/utils/first_follow.h
@@ -8,6 +8,9 @@
 #include "grammar/grammar.h"
 
 namespace jucc::utils {
+// Standard practice to mark input end
+const char STRING_ENDMARKER[] = "$";
+
 // grammar::Productions getModifiedGrammar(const grammar::Productions &);
 
 /**

--- a/src/include/utils/first_follow.h
+++ b/src/include/utils/first_follow.h
@@ -11,7 +11,7 @@ namespace jucc::utils {
 // grammar::Productions getModifiedGrammar(const grammar::Productions &);
 
 /**
- * For each terminal and non terminal in the grammar compute if symbol is nullable
+ * For each terminal and non terminal in the grammar compute if symbol is / derives to nullable
  * Terminals except EPSILON are defaulted to non nullable
  * @returns an unordered_map keyed by each symbol in the grammar of booleans
  * true if symbol is nullable, false otherwise

--- a/src/include/utils/first_follow.h
+++ b/src/include/utils/first_follow.h
@@ -21,20 +21,22 @@ const char STRING_ENDMARKER[] = "$";
  */
 std::unordered_map<std::string, bool> CalcNullables(const grammar::Productions & /*augmented_grammar*/);
 
+using SymbolsMap = std::unordered_map<std::string, std::vector<std::string>>;
+
 /**
  * For each non terminal in given set of productions computes Firsts
  * @returns an unordered_map keyed by non terminals in the grammar of a vector of terminals
  */
-std::unordered_map<std::string, std::vector<std::string>> CalcFirsts(
-    const grammar::Productions & /*augmented_grammar*/, const std::unordered_map<std::string, bool> & /*nullables*/);
+SymbolsMap CalcFirsts(const grammar::Productions & /*augmented_grammar*/,
+                      const std::unordered_map<std::string, bool> & /*nullables*/);
 
 /**
  * For each non terminal in given set of productions computes Follows
  * @returns an unordered_map keyed by non terminals in the grammar of a vector of terminals
  */
-std::unordered_map<std::string, std::vector<std::string>> CalcFollows(
-    const grammar::Productions & /*augmented_grammar*/, const std::unordered_map<std::string, bool> & /*nullables*/,
-    const std::string & /*start_symbol*/);
+SymbolsMap CalcFollows(const grammar::Productions & /*augmented_grammar*/, const SymbolsMap & /*firsts*/,
+                       const std::unordered_map<std::string, bool> & /*nullables*/,
+                       const std::string & /*start_symbol*/);
 
 }  // namespace jucc::utils
 

--- a/src/include/utils/first_follow.h
+++ b/src/include/utils/first_follow.h
@@ -1,0 +1,15 @@
+#ifndef JUCC_FIRST_FOLLOW_H
+#define JUCC_FIRST_FOLLOW_H
+#include "grammar/grammar.h"
+//using namespace std
+
+namespace jucc::utils {
+    grammar::Productions getModifiedGrammar(const grammar::Productions &);
+    bool searchParent(const grammar::Productions &, const std::string &);
+    std::vector< std::vector<std::string> > getRulesforParent(const grammar::Productions &, const std::string &);
+    std::unordered_map< std::string, bool > calcNullables(const grammar::Productions &);
+    std::unordered_map< std::string, std::vector<std::string>> calcFirsts(const grammar::Productions &,  std::unordered_map< std::string, bool > &);
+    std::unordered_map< std::string, std::vector<std::string>> calcFollows(const grammar::Productions &,  std::unordered_map< std::string, bool > &, const std::string &);
+}  // namespace jucc::utils
+
+#endif  // JUCC_FIRST_FOLLOW_H

--- a/src/include/utils/first_follow.h
+++ b/src/include/utils/first_follow.h
@@ -1,15 +1,38 @@
 #ifndef JUCC_FIRST_FOLLOW_H
 #define JUCC_FIRST_FOLLOW_H
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 #include "grammar/grammar.h"
-//using namespace std
 
 namespace jucc::utils {
-    grammar::Productions getModifiedGrammar(const grammar::Productions &);
-    bool searchParent(const grammar::Productions &, const std::string &);
-    std::vector< std::vector<std::string> > getRulesforParent(const grammar::Productions &, const std::string &);
-    std::unordered_map< std::string, bool > calcNullables(const grammar::Productions &);
-    std::unordered_map< std::string, std::vector<std::string>> calcFirsts(const grammar::Productions &,  std::unordered_map< std::string, bool > &);
-    std::unordered_map< std::string, std::vector<std::string>> calcFollows(const grammar::Productions &,  std::unordered_map< std::string, bool > &, const std::string &);
+// grammar::Productions getModifiedGrammar(const grammar::Productions &);
+
+/**
+ * For each terminal and non terminal in the grammar compute if symbol is nullable
+ * Terminals except EPSILON are defaulted to non nullable
+ * @returns an unordered_map keyed by each symbol in the grammar of booleans
+ * true if symbol is nullable, false otherwise
+ */
+std::unordered_map<std::string, bool> CalcNullables(const grammar::Productions & /*augmented_grammar*/);
+
+/**
+ * For each non terminal in given set of productions computes Firsts
+ * @returns an unordered_map keyed by non terminals in the grammar of a vector of terminals
+ */
+std::unordered_map<std::string, std::vector<std::string>> CalcFirsts(
+    const grammar::Productions & /*augmented_grammar*/, const std::unordered_map<std::string, bool> & /*nullables*/);
+
+/**
+ * For each non terminal in given set of productions computes Follows
+ * @returns an unordered_map keyed by non terminals in the grammar of a vector of terminals
+ */
+std::unordered_map<std::string, std::vector<std::string>> CalcFollows(
+    const grammar::Productions & /*augmented_grammar*/, const std::unordered_map<std::string, bool> & /*nullables*/,
+    const std::string & /*start_symbol*/);
+
 }  // namespace jucc::utils
 
 #endif  // JUCC_FIRST_FOLLOW_H

--- a/src/utils/first_follow.cpp
+++ b/src/utils/first_follow.cpp
@@ -18,10 +18,11 @@
 
 std::unordered_map<std::string, bool> CalcNullables(const grammar::Productions &augmented_grammar) {
   std::unordered_map<std::string, bool> nullables;
-  // set all terminals to not nullable
+  // set all terminals to non - nullable
   for (const auto &production : augmented_grammar) {
     for (const auto &rule : production.GetRules()) {
       for (const auto &symbol : rule.GetEntities()) {
+        // if symbol is not present as a parent in grammar, then it is a terminal
         if (!SearchParent(augmented_grammar, symbol)) {
           nullables[symbol] = false;
         }
@@ -71,52 +72,74 @@ std::unordered_map<std::string, bool> CalcNullables(const grammar::Productions &
   return nullables;
 }
 
-std::unordered_map<std::string, std::vector<std::string>> CalcFirsts(
-    const grammar::Productions &augmented_grammar, const std::unordered_map<std::string, bool> &nullables) {
+std::unordered_map<std::string, std::vector<std::string>> CalcFirsts(const grammar::Productions &augmented_grammar, const std::unordered_map<std::string, bool> &nullables) {
   std::unordered_map<std::string, std::vector<std::string>> firsts;
+  // finished -> used to check if any new symbols are added to any FIRST(non-terminal) in a particular iteration
+  // useful in case of cycles in productions
   bool finished = false;
   for (const auto &production : augmented_grammar) {
     for (const auto &rules : production.GetRules()) {
       for (const auto &symbol : rules.GetEntities()) {
-        if (SearchParent(augmented_grammar, symbol)) {
+        if (!SearchParent(augmented_grammar, symbol)) {
+          // if symbol is not present as a parent in grammar, then it is a terminal
+          // if X is a terminal, then FIRST(X) = {X}
           firsts.insert(make_pair(symbol, std::vector<std::string>(1, symbol)));
         }
       }
     }
   }
 
+  /* at this point, map of FIRST only contains terminal -> {terminal} mappings */
+
   std::function<std::vector<std::string>(const std::string &, std::vector<std::string>)> calc_recursive;
+  // key  -> current symbol being explored
+  // path -> list of all the symbols visited uptil reaching key
   calc_recursive = [&](const std::string &key, std::vector<std::string> path) {
+    // FIRST(terminal) = {terminal}
     if (!SearchParent(augmented_grammar, key)) {
       return firsts[key];
     }
 
+    // if key "belongs to" path, then first of key has already been calculated / visited
     if (find(path.begin(), path.end(), key) != path.end()) {
       return firsts[key];
     }
 
+    // marking current symbol as visited
     path.push_back(key);
+
+    /* now only un-visited non-terminals are left to be explored */
+
+    // registering non-terminal in FIRST map if encountered for the first time
     if (firsts.find(key) == firsts.end()) {
       firsts.insert(make_pair(key, std::vector<std::string>(0)));
       finished = false;
     }
 
+    /* if X is a non-terminal and X -> Y1 Y2 Y3 ... Yk is a production, then
+       for 1 <= i <= k, FIRST(X) includes FIRST(Yi) iff FIRST(Y1 ... Yi-1) => EPSILON
+       and FIRST(Y1 ... Yi-1) => EPSILON iff for all 1 <= j <= i - 1, Yj => EPSILON */
     for (const auto &rules : GetRulesForParent(augmented_grammar, key)) {
+      // symbol_itr -> iterates through all symbols in the body of a production
       std::vector<std::string>::const_iterator symbol_itr;
       for (symbol_itr = rules.GetEntities().begin(); symbol_itr != rules.GetEntities().end(); symbol_itr++) {
+        // deriving FIRST(current symbol)
         std::vector<std::string> first = calc_recursive(*symbol_itr, path);
         for (const auto &der : first) {
           if (der != std::string(grammar::EPSILON) && find(firsts[key].begin(), firsts[key].end(), der) == firsts[key].end()) {
+            // include all terminals except EPSILON
             firsts[key].push_back(der);
             finished = false;
           }
         }
 
+        // non-symbol symbol encountered, so no need of deriving succeeding symbols
         if (!nullables.at(*symbol_itr)) {
           break;
         }
       }
 
+      // if all symbols of the body of a production yielded to EPSILON, then FIRST(key) includes EPSILON
       if (symbol_itr == rules.GetEntities().end() &&
           find(firsts[key].begin(), firsts[key].end(), std::string(grammar::EPSILON)) == firsts[key].end()) {
         firsts[key].push_back(std::string(grammar::EPSILON));
@@ -126,6 +149,15 @@ std::unordered_map<std::string, std::vector<std::string>> CalcFirsts(
     return firsts[key];
   };
 
+  /*
+      Continue finding FIRST of all non-terminals in grammar as long as some changes are committed
+      In case of cycles in productions, we may need to iterate multiple times
+
+      For example, A -> C a, B -> C b, C -> B c | EPSILON
+      After iteration 1: FIRST(A) = {a}, FIRST(B) = {b}, FIRST(C) = {EPSILON, b}, finished = false
+      After iteration 2: FIRST(A) = {a, b}, FIRST(B) = {b}, FIRST(C) = {EPSILON, b}, finished = false
+      After iteration 3: no changes -> stop, finished = true
+  */
   while (!finished) {
     finished = true;
     for (const auto &production : augmented_grammar) {
@@ -133,6 +165,7 @@ std::unordered_map<std::string, std::vector<std::string>> CalcFirsts(
     }
   }
 
+  // sorting FIRST mappings for convenience in presentation
   for (const auto &production : augmented_grammar) {
     sort(firsts[production.GetParent()].begin(), firsts[production.GetParent()].end());
   }
@@ -161,7 +194,7 @@ std::unordered_map<std::string, std::vector<std::string>> CalcFollows(
       std::vector<std::string>::const_iterator next_itr;
       for (symbol_itr = rule.GetEntities().begin(); symbol_itr != rule.GetEntities().end(); symbol_itr++) {
         std::string mid = *symbol_itr;
-        if (SearchParent(augmented_grammar, key)) {
+        if (SearchParent(augmented_grammar, mid)) {
           for (next_itr = symbol_itr + 1; next_itr != rule.GetEntities().end(); next_itr++) {
             for (const auto &der : firsts[*next_itr]) {
               if (der != std::string(grammar::EPSILON) &&

--- a/src/utils/first_follow.cpp
+++ b/src/utils/first_follow.cpp
@@ -1,0 +1,207 @@
+#include "utils/first_follow.h"
+#include <functional>
+#include "utils/left_factoring.h"
+#include "utils/left_recursion.h"
+using namespace std;
+bool searchParent(const grammar::Productions &productions, const std::string &parent)
+{
+    for (auto production : productions) {
+        if (production.GetParent() == parent) {
+            return true;
+        }
+    }
+    return false;
+}
+
+std::vector< std::vector<std::string> > getRulesforParent(const grammar::Productions &productions, const std::string &parent)
+{
+    std::vector< std::vector<std::string> > rules;
+    for (auto production : productions) {
+        if (production.GetParent() == parent) {
+            for (auto rule : production.GetRules()) {
+                rules.push_back(rule.GetEntities());
+            }
+            break;
+        }
+    }
+    return rules;
+}
+
+grammar::Productions getModifiedGrammar(const grammar:: Productions &prods)
+{
+    grammar::Productions cache;
+    for (const auto& prod : prods) {
+        for(const auto& nag : jucc::utils::RemoveDirectLeftRecursion(prod))
+        {
+            auto micro_nag = jucc::utils::RemoveLeftFactors(nag);
+            cache.insert(cache.end(), micro_nag.begin(), micro_nag.end());
+        }
+    }
+    return cache;
+}
+
+std::unordered_map< std::string, bool > calcNullables(const grammar::Productions &augmentedGrammar)
+{
+    std::unordered_map< std::string, bool > nullables;
+    for (const auto& production : augmentedGrammar) {
+        for (const auto& body : production.GetRules()) {
+            for (const auto& symbol : body.GetEntities()) {
+                if (!searchParent(augmentedGrammar, symbol)) {
+                    nullables[symbol] = false;
+                }
+            }
+        }
+    }
+    if (nullables.find(std::string(grammar::EPSILON)) != nullables.end()) {
+        nullables[std::string(grammar::EPSILON)] = true;
+    }
+    std::function<bool(const std::string&, std::vector<std::string>)> calcRec;
+    calcRec = [&] (const std::string& key, std::vector<std::string> path)
+    {
+        if (find(path.begin(), path.end(), key) != path.end()) {
+            return false;
+        }
+        path.push_back(key);
+        if (nullables.find(key) != nullables.end()) {
+            return nullables[key];
+        }
+        for (auto body : getRulesforParent(augmentedGrammar, key)) {
+            std::vector<std::string>::iterator symbol;
+            for (symbol = body.begin(); symbol != body.end(); symbol++) {
+                if (!calcRec(*symbol, path)) {
+                    break;
+                }
+            }
+            if (symbol == body.end()) {
+                nullables[key] = true;
+                return true;
+            }
+        }
+        nullables[key] = false;
+        return false;
+    };
+    for (const auto& production : augmentedGrammar)
+    {
+        calcRec(production.GetParent(), std::vector<std::string> (0));
+    }
+    return nullables;
+}
+
+std::unordered_map< std::string, std::vector<std::string> > calcFirsts(const grammar::Productions &augmentedGrammar, std::unordered_map< std::string, bool> &nullables)
+{
+    std::unordered_map< std::string, std::vector<std::string> > firsts;
+    bool finished = false;
+    for (const auto& production : augmentedGrammar) {
+        for (const auto& body : production.GetRules()) {
+            for (const auto& symbol : body.GetEntities()) {
+                if (searchParent(augmentedGrammar, symbol)) {
+                    firsts.insert(make_pair(symbol, std::vector<std::string> (1, symbol)));
+                }
+            }
+        }
+    }
+    std::function<std::vector<std::string>(const std::string&, std::vector<std::string>)> calcRec;
+    calcRec = [&] (const std::string& key, std::vector<std::string> path)
+    {
+        if (!searchParent(augmentedGrammar, key)) {
+            return firsts[key];
+        }
+        if (find(path.begin(), path.end(), key) != path.end()) {
+            return firsts[key];
+        }
+        path.push_back(key);
+        if (firsts.find(key) == firsts.end()) {
+            firsts.insert(make_pair(key, std::vector<std::string> (0)));
+            finished = false;
+        }
+        for (auto body : getRulesforParent(augmentedGrammar, key)) {
+            std::vector<std::string>::iterator symbol;
+            for (symbol = body.begin(); symbol != body.end(); symbol++) {
+                std::vector<std::string> first = calcRec(*symbol, path);
+                for (const auto& der : first) {
+                    if (der != "E" && find(firsts[key].begin(), firsts[key].end(), der) == firsts[key].end()) {
+                        firsts[key].push_back(der);
+                        finished = false;
+                    }
+                }
+                if (!nullables[*symbol]) {
+                    break;
+                }
+            }
+            if (symbol == body.end() && find(firsts[key].begin(), firsts[key].end(), std::string(grammar::EPSILON)) == firsts[key].end()) {
+                firsts[key].push_back(std::string(grammar::EPSILON));
+            }
+        }
+        return firsts[key];
+    };
+    while  (!finished) {
+        finished = true;
+        for (const auto& production : augmentedGrammar)
+        {
+            calcRec(production.GetParent(), std::vector<std::string> (0));
+        }
+    }
+    for (const auto& production : augmentedGrammar) {
+        sort(firsts[production.GetParent()].begin(), firsts[production.GetParent()].end());
+    }
+    return firsts;
+}
+
+std::unordered_map< string, vector<string> > calcFollows(const grammar::Productions &augmentedGrammar,  std::unordered_map< std::string, bool> nullables, const std::string &start_symbol)
+{
+    std::unordered_map< string, vector<string> > follows;
+    std::unordered_map< std::string, std::vector<std::string> > firsts = calcFirsts(augmentedGrammar, nullables   );
+    bool finished = false;
+    for (const auto& production : augmentedGrammar) {
+        if (production.GetParent() == start_symbol)
+            follows.insert(make_pair(production.GetParent(), std::vector<std::string> (1, "$")));
+        else
+            follows.insert(make_pair(production.GetParent(), std::vector<std::string> (0)));
+    }
+    std::function<void(const std::string&, std::vector<std::string>)> calcRec;
+    calcRec = [&] (const std::string& key, const std::vector<std::string>& path)
+    {
+        for (auto body : getRulesforParent(augmentedGrammar, key)) {
+            std::vector<std::string>::iterator symbol_itr, next_itr;
+//            auto ss = *next_itr;
+            for (symbol_itr = body.begin(); symbol_itr != body.end(); symbol_itr++) {
+                std::string mid = *symbol_itr;
+                if (searchParent(augmentedGrammar, key)) {
+                    for (next_itr = symbol_itr + 1; next_itr != body.end(); next_itr++) {
+                        for (const auto& der : firsts[*next_itr]) {
+                            if (der != std::string(grammar::EPSILON) && find(follows[mid].begin(), follows[mid].end(), der) == follows[mid].end()) {
+                                follows[mid].push_back(der);
+                                finished = false;
+                            }
+                        }
+                        if (!nullables[ *next_itr ]) {
+                            break;
+                        }
+                    }
+                    if (next_itr == body.end()) {
+                        for (const auto& der : follows[key])
+                        {
+                            if (find(follows[mid].begin(), follows[mid].end(), der) == follows[mid].end()) {
+                                follows[mid].push_back(der);
+                                finished = false;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+    while  (!finished) {
+        finished = true;
+        calcRec("S", std::vector<std::string> (0));
+        for (const auto& production : augmentedGrammar)
+        {
+            if (production.GetParent() != start_symbol)
+                calcRec(production.GetParent(), std::vector<std::string> (0));
+        }
+    }
+    for (const auto& production : augmentedGrammar) {
+        sort(follows[production.GetParent()].begin(), follows[production.GetParent()].end());
+    }
+    return follows;
+}

--- a/src/utils/first_follow.cpp
+++ b/src/utils/first_follow.cpp
@@ -106,7 +106,7 @@ std::unordered_map<std::string, std::vector<std::string>> CalcFirsts(
       for (symbol_itr = rules.GetEntities().begin(); symbol_itr != rules.GetEntities().end(); symbol_itr++) {
         std::vector<std::string> first = calc_recursive(*symbol_itr, path);
         for (const auto &der : first) {
-          if (der != "E" && find(firsts[key].begin(), firsts[key].end(), der) == firsts[key].end()) {
+          if (der != std::string(grammar::EPSILON) && find(firsts[key].begin(), firsts[key].end(), der) == firsts[key].end()) {
             firsts[key].push_back(der);
             finished = false;
           }
@@ -191,7 +191,7 @@ std::unordered_map<std::string, std::vector<std::string>> CalcFollows(
 
   while (!finished) {
     finished = true;
-    calc_recursive("S", std::vector<std::string>(0));
+    calc_recursive(start_symbol, std::vector<std::string>(0));
     for (const auto &production : augmented_grammar) {
       if (production.GetParent() != start_symbol) {
         calc_recursive(production.GetParent(), std::vector<std::string>(0));

--- a/src/utils/first_follow.cpp
+++ b/src/utils/first_follow.cpp
@@ -132,8 +132,13 @@ std::unordered_map<std::string, std::vector<std::string>> CalcFirsts(const gramm
         // deriving FIRST(current symbol)
         std::vector<std::string> first = calc_recursive(*symbol_itr, path);
         for (const auto &der : first) {
+<<<<<<< HEAD
           if (der != std::string(grammar::EPSILON) && find(firsts[key].begin(), firsts[key].end(), der) == firsts[key].end()) {
             // include all terminals except EPSILON
+=======
+          if (der != std::string(grammar::EPSILON) &&
+              find(firsts[key].begin(), firsts[key].end(), der) == firsts[key].end()) {
+>>>>>>> f938ede... Added: const char[] '$'
             firsts[key].push_back(der);
             finished = false;
           }
@@ -187,7 +192,7 @@ std::unordered_map<std::string, std::vector<std::string>> CalcFollows(
   bool finished = false;
   for (const auto &production : augmented_grammar) {
     if (production.GetParent() == start_symbol) {
-      follows.insert(make_pair(production.GetParent(), std::vector<std::string>(1, "$")));
+      follows.insert(make_pair(production.GetParent(), std::vector<std::string>(1, std::string(STRING_ENDMARKER))));
     } else {
       follows.insert(make_pair(production.GetParent(), std::vector<std::string>(0)));
     }

--- a/src/utils/first_follow.cpp
+++ b/src/utils/first_follow.cpp
@@ -1,207 +1,207 @@
 #include "utils/first_follow.h"
+
 #include <functional>
+
 #include "utils/left_factoring.h"
 #include "utils/left_recursion.h"
-using namespace std;
-bool searchParent(const grammar::Productions &productions, const std::string &parent)
-{
-    for (auto production : productions) {
-        if (production.GetParent() == parent) {
-            return true;
+
+// grammar::Productions getModifiedGrammar(const grammar::Productions &prods) {
+//   grammar::Productions cache;
+//   for (const auto &prod : prods) {
+//     for (const auto &nag : jucc::utils::RemoveDirectLeftRecursion(prod)) {
+//       auto micro_nag = jucc::utils::RemoveLeftFactors(nag);
+//       cache.insert(cache.end(), micro_nag.begin(), micro_nag.end());
+//     }
+//   }
+//   return cache;
+// }
+
+std::unordered_map<std::string, bool> CalcNullables(const grammar::Productions &augmented_grammar) {
+  std::unordered_map<std::string, bool> nullables;
+  // set all terminals to not nullable
+  for (const auto &production : augmented_grammar) {
+    for (const auto &rule : production.GetRules()) {
+      for (const auto &symbol : rule.GetEntities()) {
+        if (!SearchParent(augmented_grammar, symbol)) {
+          nullables[symbol] = false;
         }
+      }
     }
+  }
+
+  // EPSILON is nullable by defination
+  if (nullables.find(std::string(grammar::EPSILON)) != nullables.end()) {
+    nullables[std::string(grammar::EPSILON)] = true;
+  }
+
+  // recursively compute for all non terminals
+  std::function<bool(const std::string &, std::vector<std::string>)> calc_recursive;
+  calc_recursive = [&](const std::string &key, std::vector<std::string> path) {
+    if (find(path.begin(), path.end(), key) != path.end()) {
+      return false;
+    }
+
+    path.push_back(key);
+    if (nullables.find(key) != nullables.end()) {
+      return nullables[key];
+    }
+
+    for (const auto &rule : GetRulesForParent(augmented_grammar, key)) {
+      std::vector<std::string>::const_iterator symbol_itr;
+      for (symbol_itr = rule.GetEntities().begin(); symbol_itr != rule.GetEntities().end(); symbol_itr++) {
+        if (!calc_recursive(*symbol_itr, path)) {
+          break;
+        }
+      }
+
+      if (symbol_itr == rule.GetEntities().end()) {
+        nullables[key] = true;
+        return true;
+      }
+    }
+
+    nullables[key] = false;
     return false;
+  };
+
+  for (const auto &production : augmented_grammar) {
+    calc_recursive(production.GetParent(), std::vector<std::string>(0));
+  }
+
+  return nullables;
 }
 
-std::vector< std::vector<std::string> > getRulesforParent(const grammar::Productions &productions, const std::string &parent)
-{
-    std::vector< std::vector<std::string> > rules;
-    for (auto production : productions) {
-        if (production.GetParent() == parent) {
-            for (auto rule : production.GetRules()) {
-                rules.push_back(rule.GetEntities());
-            }
-            break;
+std::unordered_map<std::string, std::vector<std::string>> CalcFirsts(
+    const grammar::Productions &augmented_grammar, const std::unordered_map<std::string, bool> &nullables) {
+  std::unordered_map<std::string, std::vector<std::string>> firsts;
+  bool finished = false;
+  for (const auto &production : augmented_grammar) {
+    for (const auto &rules : production.GetRules()) {
+      for (const auto &symbol : rules.GetEntities()) {
+        if (SearchParent(augmented_grammar, symbol)) {
+          firsts.insert(make_pair(symbol, std::vector<std::string>(1, symbol)));
         }
+      }
     }
-    return rules;
-}
+  }
 
-grammar::Productions getModifiedGrammar(const grammar:: Productions &prods)
-{
-    grammar::Productions cache;
-    for (const auto& prod : prods) {
-        for(const auto& nag : jucc::utils::RemoveDirectLeftRecursion(prod))
-        {
-            auto micro_nag = jucc::utils::RemoveLeftFactors(nag);
-            cache.insert(cache.end(), micro_nag.begin(), micro_nag.end());
-        }
+  std::function<std::vector<std::string>(const std::string &, std::vector<std::string>)> calc_recursive;
+  calc_recursive = [&](const std::string &key, std::vector<std::string> path) {
+    if (!SearchParent(augmented_grammar, key)) {
+      return firsts[key];
     }
-    return cache;
-}
 
-std::unordered_map< std::string, bool > calcNullables(const grammar::Productions &augmentedGrammar)
-{
-    std::unordered_map< std::string, bool > nullables;
-    for (const auto& production : augmentedGrammar) {
-        for (const auto& body : production.GetRules()) {
-            for (const auto& symbol : body.GetEntities()) {
-                if (!searchParent(augmentedGrammar, symbol)) {
-                    nullables[symbol] = false;
-                }
-            }
-        }
+    if (find(path.begin(), path.end(), key) != path.end()) {
+      return firsts[key];
     }
-    if (nullables.find(std::string(grammar::EPSILON)) != nullables.end()) {
-        nullables[std::string(grammar::EPSILON)] = true;
-    }
-    std::function<bool(const std::string&, std::vector<std::string>)> calcRec;
-    calcRec = [&] (const std::string& key, std::vector<std::string> path)
-    {
-        if (find(path.begin(), path.end(), key) != path.end()) {
-            return false;
-        }
-        path.push_back(key);
-        if (nullables.find(key) != nullables.end()) {
-            return nullables[key];
-        }
-        for (auto body : getRulesforParent(augmentedGrammar, key)) {
-            std::vector<std::string>::iterator symbol;
-            for (symbol = body.begin(); symbol != body.end(); symbol++) {
-                if (!calcRec(*symbol, path)) {
-                    break;
-                }
-            }
-            if (symbol == body.end()) {
-                nullables[key] = true;
-                return true;
-            }
-        }
-        nullables[key] = false;
-        return false;
-    };
-    for (const auto& production : augmentedGrammar)
-    {
-        calcRec(production.GetParent(), std::vector<std::string> (0));
-    }
-    return nullables;
-}
 
-std::unordered_map< std::string, std::vector<std::string> > calcFirsts(const grammar::Productions &augmentedGrammar, std::unordered_map< std::string, bool> &nullables)
-{
-    std::unordered_map< std::string, std::vector<std::string> > firsts;
-    bool finished = false;
-    for (const auto& production : augmentedGrammar) {
-        for (const auto& body : production.GetRules()) {
-            for (const auto& symbol : body.GetEntities()) {
-                if (searchParent(augmentedGrammar, symbol)) {
-                    firsts.insert(make_pair(symbol, std::vector<std::string> (1, symbol)));
-                }
-            }
-        }
+    path.push_back(key);
+    if (firsts.find(key) == firsts.end()) {
+      firsts.insert(make_pair(key, std::vector<std::string>(0)));
+      finished = false;
     }
-    std::function<std::vector<std::string>(const std::string&, std::vector<std::string>)> calcRec;
-    calcRec = [&] (const std::string& key, std::vector<std::string> path)
-    {
-        if (!searchParent(augmentedGrammar, key)) {
-            return firsts[key];
-        }
-        if (find(path.begin(), path.end(), key) != path.end()) {
-            return firsts[key];
-        }
-        path.push_back(key);
-        if (firsts.find(key) == firsts.end()) {
-            firsts.insert(make_pair(key, std::vector<std::string> (0)));
+
+    for (const auto &rules : GetRulesForParent(augmented_grammar, key)) {
+      std::vector<std::string>::const_iterator symbol_itr;
+      for (symbol_itr = rules.GetEntities().begin(); symbol_itr != rules.GetEntities().end(); symbol_itr++) {
+        std::vector<std::string> first = calc_recursive(*symbol_itr, path);
+        for (const auto &der : first) {
+          if (der != "E" && find(firsts[key].begin(), firsts[key].end(), der) == firsts[key].end()) {
+            firsts[key].push_back(der);
             finished = false;
+          }
         }
-        for (auto body : getRulesforParent(augmentedGrammar, key)) {
-            std::vector<std::string>::iterator symbol;
-            for (symbol = body.begin(); symbol != body.end(); symbol++) {
-                std::vector<std::string> first = calcRec(*symbol, path);
-                for (const auto& der : first) {
-                    if (der != "E" && find(firsts[key].begin(), firsts[key].end(), der) == firsts[key].end()) {
-                        firsts[key].push_back(der);
-                        finished = false;
-                    }
-                }
-                if (!nullables[*symbol]) {
-                    break;
-                }
-            }
-            if (symbol == body.end() && find(firsts[key].begin(), firsts[key].end(), std::string(grammar::EPSILON)) == firsts[key].end()) {
-                firsts[key].push_back(std::string(grammar::EPSILON));
-            }
+
+        if (!nullables.at(*symbol_itr)) {
+          break;
         }
-        return firsts[key];
-    };
-    while  (!finished) {
-        finished = true;
-        for (const auto& production : augmentedGrammar)
-        {
-            calcRec(production.GetParent(), std::vector<std::string> (0));
-        }
+      }
+
+      if (symbol_itr == rules.GetEntities().end() &&
+          find(firsts[key].begin(), firsts[key].end(), std::string(grammar::EPSILON)) == firsts[key].end()) {
+        firsts[key].push_back(std::string(grammar::EPSILON));
+      }
     }
-    for (const auto& production : augmentedGrammar) {
-        sort(firsts[production.GetParent()].begin(), firsts[production.GetParent()].end());
+
+    return firsts[key];
+  };
+
+  while (!finished) {
+    finished = true;
+    for (const auto &production : augmented_grammar) {
+      calc_recursive(production.GetParent(), std::vector<std::string>(0));
     }
-    return firsts;
+  }
+
+  for (const auto &production : augmented_grammar) {
+    sort(firsts[production.GetParent()].begin(), firsts[production.GetParent()].end());
+  }
+
+  return firsts;
 }
 
-std::unordered_map< string, vector<string> > calcFollows(const grammar::Productions &augmentedGrammar,  std::unordered_map< std::string, bool> nullables, const std::string &start_symbol)
-{
-    std::unordered_map< string, vector<string> > follows;
-    std::unordered_map< std::string, std::vector<std::string> > firsts = calcFirsts(augmentedGrammar, nullables   );
-    bool finished = false;
-    for (const auto& production : augmentedGrammar) {
-        if (production.GetParent() == start_symbol)
-            follows.insert(make_pair(production.GetParent(), std::vector<std::string> (1, "$")));
-        else
-            follows.insert(make_pair(production.GetParent(), std::vector<std::string> (0)));
+std::unordered_map<std::string, std::vector<std::string>> CalcFollows(
+    const grammar::Productions &augmented_grammar, const std::unordered_map<std::string, bool> nullables,
+    const std::string &start_symbol) {
+  std::unordered_map<std::string, std::vector<std::string>> follows;
+  std::unordered_map<std::string, std::vector<std::string>> firsts = CalcFirsts(augmented_grammar, nullables);
+  bool finished = false;
+  for (const auto &production : augmented_grammar) {
+    if (production.GetParent() == start_symbol) {
+      follows.insert(make_pair(production.GetParent(), std::vector<std::string>(1, "$")));
+    } else {
+      follows.insert(make_pair(production.GetParent(), std::vector<std::string>(0)));
     }
-    std::function<void(const std::string&, std::vector<std::string>)> calcRec;
-    calcRec = [&] (const std::string& key, const std::vector<std::string>& path)
-    {
-        for (auto body : getRulesforParent(augmentedGrammar, key)) {
-            std::vector<std::string>::iterator symbol_itr, next_itr;
-//            auto ss = *next_itr;
-            for (symbol_itr = body.begin(); symbol_itr != body.end(); symbol_itr++) {
-                std::string mid = *symbol_itr;
-                if (searchParent(augmentedGrammar, key)) {
-                    for (next_itr = symbol_itr + 1; next_itr != body.end(); next_itr++) {
-                        for (const auto& der : firsts[*next_itr]) {
-                            if (der != std::string(grammar::EPSILON) && find(follows[mid].begin(), follows[mid].end(), der) == follows[mid].end()) {
-                                follows[mid].push_back(der);
-                                finished = false;
-                            }
-                        }
-                        if (!nullables[ *next_itr ]) {
-                            break;
-                        }
-                    }
-                    if (next_itr == body.end()) {
-                        for (const auto& der : follows[key])
-                        {
-                            if (find(follows[mid].begin(), follows[mid].end(), der) == follows[mid].end()) {
-                                follows[mid].push_back(der);
-                                finished = false;
-                            }
-                        }
-                    }
-                }
+  }
+
+  std::function<void(const std::string &, const std::vector<std::string> &)> calc_recursive;
+  calc_recursive = [&](const std::string &key, const std::vector<std::string> &path) {
+    for (const auto &rule : GetRulesForParent(augmented_grammar, key)) {
+      std::vector<std::string>::const_iterator symbol_itr;
+      std::vector<std::string>::const_iterator next_itr;
+      for (symbol_itr = rule.GetEntities().begin(); symbol_itr != rule.GetEntities().end(); symbol_itr++) {
+        std::string mid = *symbol_itr;
+        if (SearchParent(augmented_grammar, key)) {
+          for (next_itr = symbol_itr + 1; next_itr != rule.GetEntities().end(); next_itr++) {
+            for (const auto &der : firsts[*next_itr]) {
+              if (der != std::string(grammar::EPSILON) &&
+                  find(follows[mid].begin(), follows[mid].end(), der) == follows[mid].end()) {
+                follows[mid].push_back(der);
+                finished = false;
+              }
             }
+
+            if (!nullables.at(*next_itr)) {
+              break;
+            }
+          }
+
+          if (next_itr == rule.GetEntities().end()) {
+            for (const auto &der : follows[key]) {
+              if (find(follows[mid].begin(), follows[mid].end(), der) == follows[mid].end()) {
+                follows[mid].push_back(der);
+                finished = false;
+              }
+            }
+          }
         }
-    };
-    while  (!finished) {
-        finished = true;
-        calcRec("S", std::vector<std::string> (0));
-        for (const auto& production : augmentedGrammar)
-        {
-            if (production.GetParent() != start_symbol)
-                calcRec(production.GetParent(), std::vector<std::string> (0));
-        }
+      }
     }
-    for (const auto& production : augmentedGrammar) {
-        sort(follows[production.GetParent()].begin(), follows[production.GetParent()].end());
+  };
+
+  while (!finished) {
+    finished = true;
+    calc_recursive("S", std::vector<std::string>(0));
+    for (const auto &production : augmented_grammar) {
+      if (production.GetParent() != start_symbol) {
+        calc_recursive(production.GetParent(), std::vector<std::string>(0));
+      }
     }
-    return follows;
+  }
+
+  for (const auto &production : augmented_grammar) {
+    sort(follows[production.GetParent()].begin(), follows[production.GetParent()].end());
+  }
+
+  return follows;
 }

--- a/src/utils/first_follow.cpp
+++ b/src/utils/first_follow.cpp
@@ -16,6 +16,8 @@
 //   return cache;
 // }
 
+namespace jucc::utils {
+
 std::unordered_map<std::string, bool> CalcNullables(const grammar::Productions &augmented_grammar) {
   std::unordered_map<std::string, bool> nullables;
   // set all terminals to non - nullable
@@ -36,14 +38,15 @@ std::unordered_map<std::string, bool> CalcNullables(const grammar::Productions &
   }
 
   // recursively compute for all non terminals
-  std::function<bool(const std::string &, std::vector<std::string>)> calc_recursive;
-  calc_recursive = [&](const std::string &key, std::vector<std::string> path) {
+  std::function<bool(const std::string &, std::vector<std::string> &)> calc_recursive;
+  calc_recursive = [&](const std::string &key, std::vector<std::string> &path) {
     if (find(path.begin(), path.end(), key) != path.end()) {
       return false;
     }
 
     path.push_back(key);
     if (nullables.find(key) != nullables.end()) {
+      path.pop_back();
       return nullables[key];
     }
 
@@ -57,16 +60,19 @@ std::unordered_map<std::string, bool> CalcNullables(const grammar::Productions &
 
       if (symbol_itr == rule.GetEntities().end()) {
         nullables[key] = true;
+        path.pop_back();
         return true;
       }
     }
 
     nullables[key] = false;
+    path.pop_back();
     return false;
   };
 
   for (const auto &production : augmented_grammar) {
-    calc_recursive(production.GetParent(), std::vector<std::string>(0));
+    std::vector<std::string> path = std::vector<std::string>(0);
+    calc_recursive(production.GetParent(), path);
   }
 
   return nullables;
@@ -238,3 +244,5 @@ std::unordered_map<std::string, std::vector<std::string>> CalcFollows(
 
   return follows;
 }
+
+}  // namespace jucc::utils

--- a/test/grammar/grammar_test.cpp
+++ b/test/grammar/grammar_test.cpp
@@ -74,28 +74,22 @@ TEST(grammar, parser3) {
   ASSERT_EQ("grammar parsing error: invalid token %rules", parser.GetError());
 }
 
-TEST(grammar, parser3b) {
-  Parser parser = Parser("../test/grammar/grammar_test_3b.g");
-  ASSERT_EQ(false, parser.Parse());
-  ASSERT_EQ("grammar parsing error: invalid token %start", parser.GetError());
-}
-
 TEST(grammar, parser4) {
   Parser parser = Parser("../test/grammar/grammar_test_4.g");
   ASSERT_EQ(false, parser.Parse());
-  ASSERT_EQ("grammar parsing error: invalid token %", parser.GetError());
+  ASSERT_EQ("grammar parsing error: invalid token %start", parser.GetError());
 }
 
 TEST(grammar, parser5) {
   Parser parser = Parser("../test/grammar/grammar_test_5.g");
   ASSERT_EQ(false, parser.Parse());
-  ASSERT_EQ("grammar parsing error: invalid token outside block: bruh", parser.GetError());
+  ASSERT_EQ("grammar parsing error: invalid token %", parser.GetError());
 }
 
 TEST(grammar, parser6) {
   Parser parser = Parser("../test/grammar/grammar_test_6.g");
   ASSERT_EQ(false, parser.Parse());
-  ASSERT_EQ("grammar parsing error: EPSILON is reserved", parser.GetError());
+  ASSERT_EQ("grammar parsing error: invalid token outside block: bruh", parser.GetError());
 }
 
 TEST(grammar, parser7) {
@@ -107,64 +101,70 @@ TEST(grammar, parser7) {
 TEST(grammar, parser8) {
   Parser parser = Parser("../test/grammar/grammar_test_8.g");
   ASSERT_EQ(false, parser.Parse());
-  ASSERT_EQ("grammar parsing error: ambiguous start symbol", parser.GetError());
+  ASSERT_EQ("grammar parsing error: EPSILON is reserved", parser.GetError());
 }
 
 TEST(grammar, parser9) {
   Parser parser = Parser("../test/grammar/grammar_test_9.g");
   ASSERT_EQ(false, parser.Parse());
-  ASSERT_EQ("grammar parsing error: production cannot start with EPSILON", parser.GetError());
+  ASSERT_EQ("grammar parsing error: ambiguous start symbol", parser.GetError());
 }
 
 TEST(grammar, parser10) {
   Parser parser = Parser("../test/grammar/grammar_test_10.g");
   ASSERT_EQ(false, parser.Parse());
-  ASSERT_EQ("grammar parsing error: rules syntax error ':' expected: bruh", parser.GetError());
+  ASSERT_EQ("grammar parsing error: production cannot start with EPSILON", parser.GetError());
 }
 
 TEST(grammar, parser11) {
   Parser parser = Parser("../test/grammar/grammar_test_11.g");
   ASSERT_EQ(false, parser.Parse());
-  ASSERT_EQ("grammar parsing error: rules syntax error ':' expected", parser.GetError());
+  ASSERT_EQ("grammar parsing error: rules syntax error ':' expected: bruh", parser.GetError());
 }
 
 TEST(grammar, parser12) {
   Parser parser = Parser("../test/grammar/grammar_test_12.g");
   ASSERT_EQ(false, parser.Parse());
-  ASSERT_EQ("grammar parsing error: block is incomplete '%' expected", parser.GetError());
+  ASSERT_EQ("grammar parsing error: rules syntax error ':' expected", parser.GetError());
 }
 
 TEST(grammar, parser13) {
   Parser parser = Parser("../test/grammar/grammar_test_13.g");
   ASSERT_EQ(false, parser.Parse());
-  ASSERT_EQ("grammar parsing error: inconsistent or duplicate terminals", parser.GetError());
+  ASSERT_EQ("grammar parsing error: block is incomplete '%' expected", parser.GetError());
 }
 
 TEST(grammar, parser14) {
   Parser parser = Parser("../test/grammar/grammar_test_14.g");
   ASSERT_EQ(false, parser.Parse());
-  ASSERT_EQ("grammar parsing error: inconsistent or duplicate non_terminals", parser.GetError());
+  ASSERT_EQ("grammar parsing error: inconsistent or duplicate terminals", parser.GetError());
 }
 
 TEST(grammar, parser15) {
   Parser parser = Parser("../test/grammar/grammar_test_15.g");
   ASSERT_EQ(false, parser.Parse());
-  ASSERT_EQ("grammar parsing error: terminals and non_terminals not disjoint", parser.GetError());
+  ASSERT_EQ("grammar parsing error: inconsistent or duplicate non_terminals", parser.GetError());
 }
 
 TEST(grammar, parser16) {
   Parser parser = Parser("../test/grammar/grammar_test_16.g");
   ASSERT_EQ(false, parser.Parse());
-  ASSERT_EQ("grammar parsing error: non_terminal not found: <bruh>", parser.GetError());
+  ASSERT_EQ("grammar parsing error: terminals and non_terminals not disjoint", parser.GetError());
 }
 
 TEST(grammar, parser17) {
   Parser parser = Parser("../test/grammar/grammar_test_17.g");
   ASSERT_EQ(false, parser.Parse());
-  ASSERT_EQ("grammar parsing error: rule token is not defined: bruh", parser.GetError());
+  ASSERT_EQ("grammar parsing error: non_terminal not found: <bruh>", parser.GetError());
 }
 
 TEST(grammar, parser18) {
+  Parser parser = Parser("../test/grammar/grammar_test_18.g");
+  ASSERT_EQ(false, parser.Parse());
+  ASSERT_EQ("grammar parsing error: rule token is not defined: bruh", parser.GetError());
+}
+
+TEST(grammar, parser19) {
   Parser parser = Parser("invalid_file_path");
   ASSERT_EQ(false, parser.Parse());
   ASSERT_EQ("grammar parsing error: file not found", parser.GetError());

--- a/test/grammar/grammar_test_10.g
+++ b/test/grammar/grammar_test_10.g
@@ -25,6 +25,6 @@ identifier integer_constant float_constant
 <primary_expression> : identifier
 <primary_expression> : <constant>
 <primary_expression> : EPSILON
-<constant> bruh : integer_constant
+EPSILON : integer_constant
 <constant> : float_constant
 %

--- a/test/grammar/grammar_test_11.g
+++ b/test/grammar/grammar_test_11.g
@@ -25,6 +25,6 @@ identifier integer_constant float_constant
 <primary_expression> : identifier
 <primary_expression> : <constant>
 <primary_expression> : EPSILON
-<constant>
+<constant> bruh : integer_constant
 <constant> : float_constant
 %

--- a/test/grammar/grammar_test_12.g
+++ b/test/grammar/grammar_test_12.g
@@ -25,6 +25,6 @@ identifier integer_constant float_constant
 <primary_expression> : identifier
 <primary_expression> : <constant>
 <primary_expression> : EPSILON
-<constant> : integer_constant
+<constant>
 <constant> : float_constant
-
+%

--- a/test/grammar/grammar_test_13.g
+++ b/test/grammar/grammar_test_13.g
@@ -7,7 +7,7 @@
 else float if int void
 ( ) { } * + - / %
 << >> < > <= >= = == != ;
-identifier integer_constant float_constant ;
+identifier integer_constant float_constant
 %
 
 ## Non Terminals
@@ -27,4 +27,4 @@ identifier integer_constant float_constant ;
 <primary_expression> : EPSILON
 <constant> : integer_constant
 <constant> : float_constant
-%
+

--- a/test/grammar/grammar_test_14.g
+++ b/test/grammar/grammar_test_14.g
@@ -7,12 +7,12 @@
 else float if int void
 ( ) { } * + - / %
 << >> < > <= >= = == != ;
-identifier integer_constant float_constant
+identifier integer_constant float_constant ;
 %
 
 ## Non Terminals
 %non_terminals
-<primary_expression> <constant> <constant>
+<primary_expression> <constant>
 %
 
 ## Start Symbol

--- a/test/grammar/grammar_test_15.g
+++ b/test/grammar/grammar_test_15.g
@@ -7,12 +7,12 @@
 else float if int void
 ( ) { } * + - / %
 << >> < > <= >= = == != ;
-identifier integer_constant float_constant <constant>
+identifier integer_constant float_constant
 %
 
 ## Non Terminals
 %non_terminals
-<primary_expression> <constant>
+<primary_expression> <constant> <constant>
 %
 
 ## Start Symbol

--- a/test/grammar/grammar_test_16.g
+++ b/test/grammar/grammar_test_16.g
@@ -7,7 +7,7 @@
 else float if int void
 ( ) { } * + - / %
 << >> < > <= >= = == != ;
-identifier integer_constant float_constant
+identifier integer_constant float_constant <constant>
 %
 
 ## Non Terminals
@@ -22,7 +22,6 @@ identifier integer_constant float_constant
 
 ## Grammar for the language
 %rules
-<bruh> : identifier
 <primary_expression> : identifier
 <primary_expression> : <constant>
 <primary_expression> : EPSILON

--- a/test/grammar/grammar_test_17.g
+++ b/test/grammar/grammar_test_17.g
@@ -22,9 +22,10 @@ identifier integer_constant float_constant
 
 ## Grammar for the language
 %rules
+<bruh> : identifier
 <primary_expression> : identifier
 <primary_expression> : <constant>
 <primary_expression> : EPSILON
 <constant> : integer_constant
-<constant> : float_constant bruh
+<constant> : float_constant
 %

--- a/test/grammar/grammar_test_18.g
+++ b/test/grammar/grammar_test_18.g
@@ -15,7 +15,6 @@ identifier integer_constant float_constant
 <primary_expression> <constant>
 %
 
-%start
 ## Start Symbol
 %start
 <primary_expression>
@@ -27,5 +26,5 @@ identifier integer_constant float_constant
 <primary_expression> : <constant>
 <primary_expression> : EPSILON
 <constant> : integer_constant
-<constant> : float_constant
+<constant> : float_constant bruh
 %

--- a/test/grammar/grammar_test_4.g
+++ b/test/grammar/grammar_test_4.g
@@ -9,13 +9,13 @@ else float if int void
 << >> < > <= >= = == != ;
 identifier integer_constant float_constant
 %
-%
 
 ## Non Terminals
 %non_terminals
 <primary_expression> <constant>
 %
 
+%start
 ## Start Symbol
 %start
 <primary_expression>

--- a/test/grammar/grammar_test_5.g
+++ b/test/grammar/grammar_test_5.g
@@ -9,6 +9,7 @@ else float if int void
 << >> < > <= >= = == != ;
 identifier integer_constant float_constant
 %
+%
 
 ## Non Terminals
 %non_terminals
@@ -19,8 +20,6 @@ identifier integer_constant float_constant
 %start
 <primary_expression>
 %
-
-bruh moment
 
 ## Grammar for the language
 %rules

--- a/test/grammar/grammar_test_6.g
+++ b/test/grammar/grammar_test_6.g
@@ -9,15 +9,18 @@ else float if int void
 << >> < > <= >= = == != ;
 identifier integer_constant float_constant
 %
+
 ## Non Terminals
 %non_terminals
-<primary_expression> <constant> EPSILON
+<primary_expression> <constant>
 %
 
 ## Start Symbol
 %start
 <primary_expression>
 %
+
+bruh moment
 
 ## Grammar for the language
 %rules

--- a/test/grammar/grammar_test_7.g
+++ b/test/grammar/grammar_test_7.g
@@ -7,11 +7,11 @@
 else float if int void
 ( ) { } * + - / %
 << >> < > <= >= = == != ;
-identifier integer_constant float_constant EPSILON
+identifier integer_constant float_constant
 %
 ## Non Terminals
 %non_terminals
-<primary_expression> <constant>
+<primary_expression> <constant> EPSILON
 %
 
 ## Start Symbol

--- a/test/grammar/grammar_test_8.g
+++ b/test/grammar/grammar_test_8.g
@@ -7,9 +7,8 @@
 else float if int void
 ( ) { } * + - / %
 << >> < > <= >= = == != ;
-identifier integer_constant float_constant
+identifier integer_constant float_constant EPSILON
 %
-
 ## Non Terminals
 %non_terminals
 <primary_expression> <constant>
@@ -17,7 +16,7 @@ identifier integer_constant float_constant
 
 ## Start Symbol
 %start
-<primary_expression> <constant>
+<primary_expression>
 %
 
 ## Grammar for the language

--- a/test/grammar/grammar_test_9.g
+++ b/test/grammar/grammar_test_9.g
@@ -17,7 +17,7 @@ identifier integer_constant float_constant
 
 ## Start Symbol
 %start
-<primary_expression>
+<primary_expression> <constant>
 %
 
 ## Grammar for the language
@@ -25,6 +25,6 @@ identifier integer_constant float_constant
 <primary_expression> : identifier
 <primary_expression> : <constant>
 <primary_expression> : EPSILON
-EPSILON : integer_constant
+<constant> : integer_constant
 <constant> : float_constant
 %

--- a/test/utils/utils_test.cpp
+++ b/test/utils/utils_test.cpp
@@ -300,8 +300,11 @@ TEST(utils, CalcFirsts0) {
 
   grammar::Productions grammar = {p1, p2, p3, p4, p5, p6};
 
-  std::unordered_map<std::string, std::vector<std::string>> res =
-      utils::CalcFirsts(grammar, utils::CalcNullables(grammar));
+  utils::SymbolsMap res = utils::CalcFirsts(grammar, utils::CalcNullables(grammar));
+  for (auto &elem : res) {
+    sort(elem.second.begin(), elem.second.end());
+  }
+
   ASSERT_EQ(13, res.size());
   ASSERT_EQ(res.at("S"), std::vector<std::string>({"a"}));
   ASSERT_EQ(res.at("B"), std::vector<std::string>({"c"}));
@@ -343,8 +346,11 @@ TEST(utils, CalcFirsts1) {
   p5.SetRules({grammar::Rule({"g"})});
   grammar::Productions grammar = {p1, p2, p3, p4, p5};
 
-  std::unordered_map<std::string, std::vector<std::string>> res =
-      utils::CalcFirsts(grammar, utils::CalcNullables(grammar));
+  utils::SymbolsMap res = utils::CalcFirsts(grammar, utils::CalcNullables(grammar));
+  for (auto &elem : res) {
+    sort(elem.second.begin(), elem.second.end());
+  }
+
   ASSERT_EQ(10, res.size());
   ASSERT_EQ(res.at("S"), std::vector<std::string>({"a"}));
   ASSERT_EQ(res.at("A"), std::vector<std::string>({"a"}));
@@ -385,8 +391,11 @@ TEST(utils, CalcFirsts2) {
   p5.SetRules({grammar::Rule({"(", "E", ")"}), grammar::Rule({"id"})});
   grammar::Productions grammar = {p1, p2, p3, p4, p5};
 
-  std::unordered_map<std::string, std::vector<std::string>> res =
-      utils::CalcFirsts(grammar, utils::CalcNullables(grammar));
+  utils::SymbolsMap res = utils::CalcFirsts(grammar, utils::CalcNullables(grammar));
+  for (auto &elem : res) {
+    sort(elem.second.begin(), elem.second.end());
+  }
+
   ASSERT_EQ(11, res.size());
   ASSERT_EQ(res.at("E"), std::vector<std::string>({"(", "id"}));
   ASSERT_EQ(res.at("E'"), std::vector<std::string>({"+", grammar::EPSILON}));
@@ -416,8 +425,11 @@ TEST(utils, CalcFirsts3) {
   p3.SetRules({grammar::Rule({"B", "c"}), grammar::Rule({grammar::EPSILON})});
   grammar::Productions grammar = {p1, p2, p3};
 
-  std::unordered_map<std::string, std::vector<std::string>> res =
-      utils::CalcFirsts(grammar, utils::CalcNullables(grammar));
+  utils::SymbolsMap res = utils::CalcFirsts(grammar, utils::CalcNullables(grammar));
+  for (auto &elem : res) {
+    sort(elem.second.begin(), elem.second.end());
+  }
+
   ASSERT_EQ(7, res.size());
   ASSERT_EQ(res.at("A"), std::vector<std::string>({"a", "b"}));
   ASSERT_EQ(res.at("B"), std::vector<std::string>({"b"}));
@@ -462,8 +474,12 @@ TEST(utils, CalcFollows0) {
 
   grammar::Productions grammar = {p1, p2, p3, p4, p5, p6};
 
-  std::unordered_map<std::string, std::vector<std::string>> res =
-      utils::CalcFollows(grammar, utils::CalcNullables(grammar), "S");
+  auto nullables = utils::CalcNullables(grammar);
+  auto firsts = utils::CalcFirsts(grammar, nullables);
+  utils::SymbolsMap res = utils::CalcFollows(grammar, firsts, nullables, "S");
+  for (auto &elem : res) {
+    sort(elem.second.begin(), elem.second.end());
+  }
 
   ASSERT_EQ(6, res.size());
   ASSERT_EQ(res.at("S"), std::vector<std::string>({utils::STRING_ENDMARKER}));
@@ -506,8 +522,13 @@ TEST(utils, CalcFollow1) {
   p5.SetRules({grammar::Rule({"g"})});
   grammar::Productions grammar = {p1, p2, p3, p4, p5};
 
-  std::unordered_map<std::string, std::vector<std::string>> res =
-      utils::CalcFollows(grammar, utils::CalcNullables(grammar), "S");
+  auto nullables = utils::CalcNullables(grammar);
+  auto firsts = utils::CalcFirsts(grammar, nullables);
+  utils::SymbolsMap res = utils::CalcFollows(grammar, firsts, nullables, "S");
+  for (auto &elem : res) {
+    sort(elem.second.begin(), elem.second.end());
+  }
+
   ASSERT_EQ(5, res.size());
   ASSERT_EQ(res.at("S"), std::vector<std::string>({utils::STRING_ENDMARKER}));
   ASSERT_EQ(res.at("A"), std::vector<std::string>({utils::STRING_ENDMARKER}));
@@ -548,8 +569,13 @@ TEST(utils, CalcFollows2) {
   p5.SetRules({grammar::Rule({"(", "E", ")"}), grammar::Rule({"id"})});
   grammar::Productions grammar = {p1, p2, p3, p4, p5};
 
-  std::unordered_map<std::string, std::vector<std::string>> res =
-      utils::CalcFollows(grammar, utils::CalcNullables(grammar), "E");
+  auto nullables = utils::CalcNullables(grammar);
+  auto firsts = utils::CalcFirsts(grammar, nullables);
+  utils::SymbolsMap res = utils::CalcFollows(grammar, firsts, nullables, "E");
+  for (auto &elem : res) {
+    sort(elem.second.begin(), elem.second.end());
+  }
+
   ASSERT_EQ(5, res.size());
   ASSERT_EQ(res.at("E"), std::vector<std::string>({utils::STRING_ENDMARKER, ")"}));
   ASSERT_EQ(res.at("E'"), std::vector<std::string>({utils::STRING_ENDMARKER, ")"}));

--- a/test/utils/utils_test.cpp
+++ b/test/utils/utils_test.cpp
@@ -1,8 +1,10 @@
 #include "gtest/gtest.h"
+#include "utils/first_follow.h"
 #include "utils/left_factoring.h"
 #include "utils/left_recursion.h"
 
 namespace grammar = jucc::grammar;
+namespace utils = jucc::utils;
 
 TEST(utils, DirectLeftRecursion) {
   // E -> E + T | T | epsilon
@@ -15,10 +17,10 @@ TEST(utils, DirectLeftRecursion) {
 
   prod.SetRules({rule1, rule2, rule3});
 
-  auto prods = jucc::utils::RemoveDirectLeftRecursion(prod);
+  auto prods = utils::RemoveDirectLeftRecursion(prod);
   // output E' -> +TE' | epsilon
   // E ->   TE' | epsilonE'
-  ASSERT_EQ(prods[0].GetParent(), "E" + std::string(jucc::utils::DASH));
+  ASSERT_EQ(prods[0].GetParent(), "E" + std::string(utils::DASH));
   ASSERT_EQ(prods[1].GetParent(), "E");
 
   auto rules_e = prods[1].GetRules();
@@ -27,11 +29,11 @@ TEST(utils, DirectLeftRecursion) {
   ASSERT_EQ(rules_e.size(), 2);
   ASSERT_EQ(rules_e_dash.size(), 2);
 
-  ASSERT_EQ(rules_e_dash[0].ToString(), "+TE" + std::string(jucc::utils::DASH));
+  ASSERT_EQ(rules_e_dash[0].ToString(), "+TE" + std::string(utils::DASH));
   ASSERT_EQ(rules_e_dash[1].ToString(), std::string(grammar::EPSILON));
 
-  ASSERT_EQ(rules_e[0].ToString(), "TE" + std::string(jucc::utils::DASH));
-  ASSERT_EQ(rules_e[1].ToString(), std::string(grammar::EPSILON) + "E" + std::string(jucc::utils::DASH));
+  ASSERT_EQ(rules_e[0].ToString(), "TE" + std::string(utils::DASH));
+  ASSERT_EQ(rules_e[1].ToString(), std::string(grammar::EPSILON) + "E" + std::string(utils::DASH));
 }
 
 TEST(utils, MaxLenPrefix0) {
@@ -39,7 +41,7 @@ TEST(utils, MaxLenPrefix0) {
   grammar::Production p;
   p.SetRules({grammar::Rule({"i", "e", "S", "t", "S", "t"}), grammar::Rule({"a"}), grammar::Rule({"b"}),
               grammar::Rule({"i", "e"}), grammar::Rule({"i", "e", "S"}), grammar::Rule({"i", "e", "S", "t", "P"})});
-  auto max_len_entity = jucc::utils::LongestCommonPrefix(p);
+  auto max_len_entity = utils::LongestCommonPrefix(p);
   ASSERT_EQ(grammar::Rule(max_len_entity).ToString(), "ie");
 }
 
@@ -52,14 +54,14 @@ TEST(utils, MaxLenPrefix1) {
       grammar::Rule({"b"}),
       grammar::Rule({"i", "e", "S", "t", "S"}),
   });
-  auto max_len_entity = jucc::utils::LongestCommonPrefix(p);
+  auto max_len_entity = utils::LongestCommonPrefix(p);
   ASSERT_EQ(grammar::Rule(max_len_entity).ToString(), "ieStS");
 }
 
 TEST(utils, MaxLenPrefix2) {
   // no rule
   grammar::Production p;
-  auto max_len_entity = jucc::utils::LongestCommonPrefix(p);
+  auto max_len_entity = utils::LongestCommonPrefix(p);
   ASSERT_EQ(grammar::Rule(max_len_entity).ToString(), "");
 }
 
@@ -72,7 +74,7 @@ TEST(utils, MaxLenPrefix3) {
       grammar::Rule({"c"}),
       grammar::Rule({std::string(grammar::EPSILON)}),
   });
-  auto max_len_entity = jucc::utils::LongestCommonPrefix(p);
+  auto max_len_entity = utils::LongestCommonPrefix(p);
   ASSERT_EQ(grammar::Rule(max_len_entity).ToString(), "");
 }
 
@@ -83,14 +85,14 @@ TEST(utils, LeftFactoring0) {
   p.SetRules({grammar::Rule({"i", "e", "S", "t", "S", "t"}), grammar::Rule({"a"}), grammar::Rule({"b"}),
               grammar::Rule({"i", "e", "S", "t", "P"})});
 
-  auto lf_removed = jucc::utils::RemoveLeftFactors(p);
+  auto lf_removed = utils::RemoveLeftFactors(p);
 
   ASSERT_EQ(lf_removed.size(), 2);
   // output
   //  E -> ieStE' | a | b |
   //  E' -> St | P | epsilon
   ASSERT_EQ(lf_removed[0].GetParent(), "E");
-  ASSERT_EQ(lf_removed[1].GetParent(), "E" + std::string(jucc::utils::DASH));
+  ASSERT_EQ(lf_removed[1].GetParent(), "E" + std::string(utils::DASH));
 
   ASSERT_EQ(lf_removed[0].GetRules().size(), 3);
   ASSERT_EQ(lf_removed[1].GetRules().size(), 3);
@@ -114,7 +116,7 @@ TEST(utils, LeftFactoring1) {
       grammar::Rule({"b"}),
   });
 
-  auto lf_removed = jucc::utils::RemoveLeftFactors(p);
+  auto lf_removed = utils::RemoveLeftFactors(p);
   // output E -> ieStSt | a | b
 
   ASSERT_EQ(lf_removed.size(), 1);
@@ -134,7 +136,7 @@ TEST(utils, LeftFactoringRecursive0) {
   p.SetRules({grammar::Rule({"a"}), grammar::Rule({"a", "b"}), grammar::Rule({"a", "b", "c"}), grammar::Rule({"e"}),
               grammar::Rule({"f"})});
 
-  auto lf_removed = jucc::utils::RemoveLeftFactors(p);
+  auto lf_removed = utils::RemoveLeftFactors(p);
   // output
   //  E ->   aE' | e | f
   //  E' ->  bE'' | epsilon  //from E' -> b | bc | epsilon
@@ -143,8 +145,8 @@ TEST(utils, LeftFactoringRecursive0) {
   ASSERT_EQ(lf_removed.size(), 3);
 
   ASSERT_EQ(lf_removed[0].GetParent(), "E");
-  ASSERT_EQ(lf_removed[1].GetParent(), "E" + std::string(jucc::utils::DASH));
-  ASSERT_EQ(lf_removed[2].GetParent(), "E" + std::string(jucc::utils::DASH) + std::string(jucc::utils::DASH));
+  ASSERT_EQ(lf_removed[1].GetParent(), "E" + std::string(utils::DASH));
+  ASSERT_EQ(lf_removed[2].GetParent(), "E" + std::string(utils::DASH) + std::string(utils::DASH));
 
   ASSERT_EQ(lf_removed[0].GetRules().size(), 3);
   ASSERT_EQ(lf_removed[1].GetRules().size(), 2);
@@ -159,4 +161,100 @@ TEST(utils, LeftFactoringRecursive0) {
 
   ASSERT_EQ(lf_removed[2].GetRules()[0].ToString(), std::string(jucc::grammar::EPSILON));
   ASSERT_EQ(lf_removed[2].GetRules()[1].ToString(), "c");
+}
+
+TEST(utils, CalcNullables0) {
+  /**
+   * Test: Context Free Grammar
+   * S -> A B A C
+   * A -> a A | EPSILON
+   * B -> b B | EPSILON
+   * C -> c
+   * nullables: A, B
+   */
+  grammar::Production p1;
+  p1.SetParent("S");
+  p1.SetRules({grammar::Rule({"A", "B", "A", "C"})});
+  grammar::Production p2;
+  p2.SetParent("A");
+  p2.SetRules({grammar::Rule({"a", "A"}), grammar::Rule({grammar::EPSILON})});
+  grammar::Production p3;
+  p3.SetParent("B");
+  p3.SetRules({grammar::Rule({"b", "B"}), grammar::Rule({grammar::EPSILON})});
+  grammar::Production p4;
+  p4.SetParent("C");
+  p4.SetRules({grammar::Rule({"c"})});
+
+  grammar::Productions grammar = {p1, p2, p3, p4};
+
+  std::unordered_map<std::string, bool> res = utils::CalcNullables(grammar);
+  ASSERT_EQ(8, res.size());
+  ASSERT_FALSE(res.at("a"));
+  ASSERT_FALSE(res.at("b"));
+  ASSERT_FALSE(res.at("c"));
+  ASSERT_TRUE(res.at(grammar::EPSILON));
+  ASSERT_FALSE(res.at("S"));
+  ASSERT_TRUE(res.at("A"));
+  ASSERT_TRUE(res.at("B"));
+  ASSERT_FALSE(res.at("C"));
+}
+
+TEST(utils, CalcNullables1) {
+  /**
+   * Test: Context Free Grammar
+   * S -> A B
+   * A -> a A A | EPSILON
+   * B -> b B B | EPSILON
+   * nullables: S, A, B
+   */
+  grammar::Production p1;
+  p1.SetParent("S");
+  p1.SetRules({grammar::Rule({"A", "B"})});
+  grammar::Production p2;
+  p2.SetParent("A");
+  p2.SetRules({grammar::Rule({"a", "A", "A"}), grammar::Rule({grammar::EPSILON})});
+  grammar::Production p3;
+  p3.SetParent("B");
+  p3.SetRules({grammar::Rule({"b", "B", "B"}), grammar::Rule({grammar::EPSILON})});
+
+  grammar::Productions grammar = {p1, p2, p3};
+
+  std::unordered_map<std::string, bool> res = utils::CalcNullables(grammar);
+  ASSERT_EQ(6, res.size());
+  ASSERT_FALSE(res.at("a"));
+  ASSERT_FALSE(res.at("b"));
+  ASSERT_TRUE(res.at(grammar::EPSILON));
+  ASSERT_TRUE(res.at("S"));
+  ASSERT_TRUE(res.at("A"));
+  ASSERT_TRUE(res.at("B"));
+}
+
+TEST(utils, CalcNullables2) {
+  /**
+   * Test: Context Free Grammar
+   * S : A S A | a B | b
+   * A : B
+   * B : b | EPSILON
+   * nullables: A, B
+   */
+  grammar::Production p1;
+  p1.SetParent("S");
+  p1.SetRules({grammar::Rule({"A", "S", "A"}), grammar::Rule({"a", "B"}), grammar::Rule({"b"})});
+  grammar::Production p2;
+  p2.SetParent("A");
+  p2.SetRules({grammar::Rule({"B"})});
+  grammar::Production p3;
+  p3.SetParent("B");
+  p3.SetRules({grammar::Rule({"b"}), grammar::Rule({grammar::EPSILON})});
+
+  grammar::Productions grammar = {p1, p2, p3};
+
+  std::unordered_map<std::string, bool> res = utils::CalcNullables(grammar);
+  ASSERT_EQ(6, res.size());
+  ASSERT_FALSE(res.at("a"));
+  ASSERT_FALSE(res.at("b"));
+  ASSERT_TRUE(res.at(grammar::EPSILON));
+  ASSERT_FALSE(res.at("S"));
+  ASSERT_TRUE(res.at("A"));
+  ASSERT_TRUE(res.at("B"));
 }


### PR DESCRIPTION
# First and Follow

## Description
This pr adds first and follow computation for context-free-grammar productions.
Continuation of #10.

closes #10 

## Remaining tasks

- [x] Add unit tests
- [x] Add comments and clean up code a bit
- [x] Remove iterator based loops (Optional)

## Further work
After unit tests have been written check the recursive functions for scope of optimization.
