### PR TITLE
Introducing FlatProduction

### DIFF
--- a/src/include/utils/first_follow.h
+++ b/src/include/utils/first_follow.h
@@ -22,6 +22,14 @@ const char STRING_ENDMARKER[] = "$";
 std::unordered_map<std::string, bool> CalcNullables(const grammar::Productions & /*augmented_grammar*/);
 
 using SymbolsMap = std::unordered_map<std::string, std::vector<std::string>>;
+using FlatProductionsMap =
+    std::unordered_map<grammar::FlatProduction, std::vector<std::string>, grammar::FlatProductionHasher>;
+
+/**
+ * typecast FlatProductionsMap to SymbolsMap
+ * This is a one way ticket as information is lost
+ */
+SymbolsMap FlatProductionsMapToSymbolsMap(const FlatProductionsMap & /*flat_productions_map*/);
 
 /**
  * For each non terminal in given set of productions computes Firsts, and in case of terminals

--- a/src/utils/first_follow.cpp
+++ b/src/utils/first_follow.cpp
@@ -1,6 +1,7 @@
 #include "utils/first_follow.h"
 
 #include <functional>
+#include <unordered_set>
 
 #include "utils/left_factoring.h"
 
@@ -69,6 +70,16 @@ std::unordered_map<std::string, bool> CalcNullables(const grammar::Productions &
   }
 
   return nullables;
+}
+
+SymbolsMap FlatProductionsMapToSymbolsMap(const FlatProductionsMap &flat_productions_map) {
+  SymbolsMap sm;
+  for (const auto &fp : flat_productions_map) {
+    auto &vect = sm[fp.first.GetParent()];
+    vect.insert(vect.end(), fp.second.begin(), fp.second.end());
+  }
+
+  return sm;
 }
 
 SymbolsMap CalcFirsts(const grammar::Productions &augmented_grammar,
@@ -177,7 +188,6 @@ SymbolsMap CalcFollows(const grammar::Productions &augmented_grammar, const Symb
                        const std::unordered_map<std::string, bool> &nullables, const std::string &start_symbol) {
   SymbolsMap follows;
   bool finished = false;
-
   for (const auto &production : augmented_grammar) {
     if (production.GetParent() == start_symbol) {
       // if production head / parent is the start_symbol, then FOLLOW(head) = {$}


### PR DESCRIPTION
# Introducing Flat Productions

## Description
Current structure of first and follow makes it infeasible to compute the ll(1) parsing table.
For jucc::utils::CalcFirsts function we need to return a FlatProductionsMap instead of SymbolsMap.
This pr is a step towards this issue and aims to resolve it.

## Remaining tasks

- [ ] Change CalcFirsts to return FlatProductionsMap
- [ ] Update CalcFollows
- [ ] Rewrite unit tests

## Further work
