### PR TITLE
Added: cin and cout tokens to grammar.g

### DIFF
--- a/grammar.g
+++ b/grammar.g
@@ -7,7 +7,8 @@
 else float if int void
 ( ) { } * + - / % ,
 << >> < > <= >= = == != ;
-identifier integer_constant float_constant main
+identifier integer_constant float_constant
+main cin cout
 %
 
 ## Non Terminals
@@ -48,6 +49,8 @@ identifier integer_constant float_constant main
 <additive_expression> : <additive_expression> + <multiplicative_expression>
 <additive_expression> : <additive_expression> - <multiplicative_expression>
 <shift_expression> : <additive_expression>
+<shift_expression> : cin >> <additive_expression>
+<shift_expression> : cout << <additive_expression>
 <shift_expression> : <shift_expression> << <additive_expression>
 <shift_expression> : <shift_expression> >> <additive_expression>
 <relational_expression> : <shift_expression>

--- a/src/grammar/grammar.cpp
+++ b/src/grammar/grammar.cpp
@@ -240,7 +240,7 @@ bool Parser::Parse() {
       }
       prod.SetParent(production.first);
 
-      std::vector<Rule> rules;
+      Rules rules;
       for (const auto &rule : production.second) {
         Rule prod_rule;
         for (const auto &entity : rule) {

--- a/src/include/grammar/grammar.h
+++ b/src/include/grammar/grammar.h
@@ -46,16 +46,16 @@ class Production {
    * rules = { Rule1, Rule2 }
    */
   std::string parent_;
-  std::vector<Rule> rules_;
+  Rules rules_;
 
  public:
   Production() = default;
-  Production(std::string parent, std::vector<Rule> rules) : parent_(std::move(parent)), rules_(std::move(rules)) {}
+  Production(std::string parent, Rules rules) : parent_(std::move(parent)), rules_(std::move(rules)) {}
 
   [[nodiscard]] const std::string &GetParent() const { return parent_; }
-  [[nodiscard]] const std::vector<Rule> &GetRules() const { return rules_; }
+  [[nodiscard]] const Rules &GetRules() const { return rules_; }
   void SetParent(const std::string &parent) { Production::parent_ = parent; }
-  void SetRules(const std::vector<Rule> &rules) { Production::rules_ = rules; }
+  void SetRules(const Rules &rules) { Production::rules_ = rules; }
 };
 
 using Productions = std::vector<Production>;


### PR DESCRIPTION
# Grammar update to support cin and cout tokens

## Description
Changed grammar.g file location as grammar.g doesn't belong inside src.
Added keywords cin and cout in grammar.
Updated std::vector<std::Rule> with Rules.

closes #21.
