### PR TITLE
Parsing Error Detection

### DIFF
--- a/src/include/parser/parser.h
+++ b/src/include/parser/parser.h
@@ -91,9 +91,7 @@ class Parser {
   void SetInputString(std::vector<std::string> inps);
   void SetParsingTable(ParsingTable table);
   void SetStartSymbol(std::string start);
-  void SetParsingTableErrors(std::vector<std::string> errs) { parsing_table_errors_ = std::move(errs); }
   [[nodiscard]] const std::vector<int> &GetProductionHistory() { return production_history_; }
-  [[nodiscard]] const std::vector<std::string> &GetParsingTableErrors() { return parsing_table_errors_; }
   [[nodiscard]] const std::vector<std::string> &GetParserErrors() { return parser_errors_; }
 };
 }  // namespace parser

--- a/src/include/parser/parser.h
+++ b/src/include/parser/parser.h
@@ -3,6 +3,7 @@
 
 #include <stack>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "parser/parsing_table.h"
@@ -49,6 +50,17 @@ class Parser {
    */
   std::vector<std::string> current_string_;
 
+  /**
+   * Errors incurred, if any, during the construction of the
+   * LL(1) parsing table.
+   */
+  std::vector<std::string> parsing_table_errors_;
+
+  /**
+   * Errors incurred during the parsing of the given input file.
+   */
+  std::vector<std::string> parser_errors_;
+
  public:
   /**
    * Constructor for initializing stack and other members.
@@ -79,7 +91,10 @@ class Parser {
   void SetInputString(std::vector<std::string> inps);
   void SetParsingTable(ParsingTable table);
   void SetStartSymbol(std::string start);
-  [[nodiscard]] const std::vector<int> &GetProductionHistory();
+  void SetParsingTableErrors(std::vector<std::string> errs) { parsing_table_errors_ = std::move(errs); }
+  [[nodiscard]] const std::vector<int> &GetProductionHistory() { return production_history_; }
+  [[nodiscard]] const std::vector<std::string> &GetParsingTableErrors() { return parsing_table_errors_; }
+  [[nodiscard]] const std::vector<std::string> &GetParserErrors() { return parser_errors_; }
 };
 }  // namespace parser
 

--- a/src/include/parser/parser.h
+++ b/src/include/parser/parser.h
@@ -51,12 +51,6 @@ class Parser {
   std::vector<std::string> current_string_;
 
   /**
-   * Errors incurred, if any, during the construction of the
-   * LL(1) parsing table.
-   */
-  std::vector<std::string> parsing_table_errors_;
-
-  /**
    * Errors incurred during the parsing of the given input file.
    */
   std::vector<std::string> parser_errors_;

--- a/src/include/parser/parsing_table.h
+++ b/src/include/parser/parsing_table.h
@@ -61,7 +61,7 @@ class ParsingTable {
   /**
    * A helper function to generate error message.
    */
-  static std::string GenerateMessage(const std::string &production, const std::string &symbol);
+  static std::string GenerateErrorMessage(const std::string &production, const std::string &symbol);
 
  public:
   /**

--- a/src/include/parser/parsing_table.h
+++ b/src/include/parser/parsing_table.h
@@ -58,6 +58,11 @@ class ParsingTable {
    */
   std::vector<std::string> errors_;
 
+  /**
+   * A helper function to generate error message.
+   */
+  std::string GenerateMessage(std::string production, std::string symbol);
+
  public:
   /**
    * Default constructor

--- a/src/include/parser/parsing_table.h
+++ b/src/include/parser/parsing_table.h
@@ -61,7 +61,7 @@ class ParsingTable {
   /**
    * A helper function to generate error message.
    */
-  std::string GenerateMessage(const std::string &production, const std::string &symbol);
+  static std::string GenerateMessage(const std::string &production, const std::string &symbol);
 
  public:
   /**

--- a/src/include/parser/parsing_table.h
+++ b/src/include/parser/parsing_table.h
@@ -52,6 +52,12 @@ class ParsingTable {
    */
   std::vector<std::string> non_terminals_;
 
+  /**
+   * Stores the errors if any, in case of a non - LL(1)
+   * grammar during the construction of the parsing table.
+   */
+  std::vector<std::string> errors_;
+
  public:
   /**
    * Default constructor
@@ -88,6 +94,7 @@ class ParsingTable {
   [[nodiscard]] const std::vector<std::string> &GetNonTerminals() { return non_terminals_; }
   [[nodiscard]] const std::vector<std::string> &GetTerminals() { return terminals_; }
   [[nodiscard]] const Table &GetTable() { return table_; }
+  [[nodiscard]] const std::vector<std::string> &GetErrors() { return errors_; }
 };
 
 }  // namespace parser

--- a/src/include/parser/parsing_table.h
+++ b/src/include/parser/parsing_table.h
@@ -61,7 +61,7 @@ class ParsingTable {
   /**
    * A helper function to generate error message.
    */
-  std::string GenerateMessage(std::string production, std::string symbol);
+  std::string GenerateMessage(const std::string &production, const std::string &symbol);
 
  public:
   /**

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -20,6 +20,8 @@
  *-------------------------------------------------------------------------
  */
 
+#include <iostream>
+
 #include "main/jucc.h"
 /**
  * jucc begins execution here.
@@ -81,8 +83,21 @@ auto main(int argc, char *argv[]) -> int {
   parser.SetStartSymbol(grammar_parser.GetStartSymbol());
   parser.SetParsingTable(parsing_table);
 
+  auto err = parsing_table.GetErrors();
+  if (!err.empty()) {
+    for (auto &e : err) {
+      std::cout << e << "\n";
+      return 0;
+    }
+  }
   while (!parser.IsComplete()) {
     parser.ParseNextStep();
+  }
+  err = parser.GetParserErrors();
+  if (!err.empty()) {
+    for (auto &e : err) {
+      std::cout << e;
+    }
   }
 
   return 0;

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -25,10 +25,14 @@
  * jucc begins execution here.
  */
 auto main(int argc, char *argv[]) -> int {
-  // print a hello world message
+  /* print a hello world message */
   std::cout << jucc::Hello();
-  jucc::InputParser input_parser = jucc::InputParser(argc, argv);
 
+  /**
+   * InputParser parses the cmd line arguments and returns
+   * input file path and grammar file path
+   */
+  jucc::InputParser input_parser = jucc::InputParser(argc, argv);
   std::string file_grammar = input_parser.GetArgument("-g");
   if (file_grammar.empty()) {
     std::cout << "jucc: usage: jucc -g <grammar_file> -f <input_file>\n";
@@ -40,25 +44,33 @@ auto main(int argc, char *argv[]) -> int {
     return 0;
   }
 
+  /* Parse the grammar file and check for formatting errors */
   jucc::grammar::Parser grammar_parser = jucc::grammar::Parser(file_grammar.c_str());
   if (!grammar_parser.Parse()) {
     std::cout << "jucc: " << grammar_parser.GetError() << '\n';
     return 0;
   }
 
+  /* Check if the input file path is good */
   std::ifstream ifs(file_input);
   if (!ifs.good()) {
     std::cout << "jucc: cannot read input file, bad file!\n";
     return 0;
   }
 
+  /**
+   * Get the parsed grammar production and process it
+   * Steps include:
+   * 1. Left recursion removal
+   * 2. Left factoring
+   */
   jucc::grammar::Productions raw_productions = grammar_parser.GetProductions();
   jucc::grammar::Productions productions = jucc::utils::RemoveAllPossibleAmbiguity(raw_productions);
 
+  /* Calculate first and follows to build the LL(1) parsing table */
   auto nullables = jucc::utils::CalcNullables(productions);
   auto firsts = jucc::utils::CalcFirsts(productions, nullables);
   auto follows = jucc::utils::CalcFollows(productions, firsts, nullables, grammar_parser.GetStartSymbol());
-
   auto terminals = grammar_parser.GetTerminals();
   auto non_terminals = jucc::utils::GetAllNonTerminals(productions);
 
@@ -68,7 +80,17 @@ auto main(int argc, char *argv[]) -> int {
   parsing_table.SetProductions(productions);
   parsing_table.BuildTable();
 
-  // use lexer to get input tokens
+  /* Check for errors in grammar and exit if errors exist */
+  auto err = parsing_table.GetErrors();
+  if (!err.empty()) {
+    std::cout << "jucc: ";
+    for (auto &e : err) {
+      std::cout << e << '\n';
+    }
+    return 0;
+  }
+
+  /* Use Lexer to get input tokens */
   std::vector<std::string> input_tokens;
   jucc::lexer::Lexer lexer = jucc::lexer::Lexer();
   int token;
@@ -76,24 +98,23 @@ auto main(int argc, char *argv[]) -> int {
     input_tokens.emplace_back(jucc::lexer::Lexer::GetTokenType(token));
   }
 
+  /* Parse the input file using the parsing table and report errors */
   jucc::parser::Parser parser = jucc::parser::Parser();
   parser.SetInputString(input_tokens);
   parser.SetStartSymbol(grammar_parser.GetStartSymbol());
   parser.SetParsingTable(parsing_table);
 
-  auto err = parsing_table.GetErrors();
-  if (!err.empty()) {
-    for (auto &e : err) {
-      std::cout << e;
-    }
-    return 0;
-  }
   while (!parser.IsComplete()) {
     parser.ParseNextStep();
   }
+
   err = parser.GetParserErrors();
-  for (auto &e : err) {
-    std::cout << e;
+  if (!err.empty()) {
+    std::cout << "jucc: ";
+    for (auto &e : err) {
+      std::cout << e << '\n';
+    }
   }
+
   return 0;
 }

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -20,8 +20,6 @@
  *-------------------------------------------------------------------------
  */
 
-#include <iostream>
-
 #include "main/jucc.h"
 /**
  * jucc begins execution here.
@@ -86,19 +84,16 @@ auto main(int argc, char *argv[]) -> int {
   auto err = parsing_table.GetErrors();
   if (!err.empty()) {
     for (auto &e : err) {
-      std::cout << e << "\n";
-      return 0;
+      std::cout << e;
     }
+    return 0;
   }
   while (!parser.IsComplete()) {
     parser.ParseNextStep();
   }
   err = parser.GetParserErrors();
-  if (!err.empty()) {
-    for (auto &e : err) {
-      std::cout << e;
-    }
+  for (auto &e : err) {
+    std::cout << e;
   }
-
   return 0;
 }

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -50,11 +50,22 @@ void Parser::DoNextStep() {
 }
 
 void Parser::ParseNextStep() {
+  // if there are parsing table errors do not perform parsing
+  if (!parsing_table_errors_.empty()) {
+    if (!parser_errors_.empty()) {
+      return;
+    }
+    parser_errors_ = parsing_table_errors_;
+    return;
+  }
   std::string top_symbol = stack_.top();
   std::string current_token = current_string_[current_step_];
   ParsingTable::Table table = table_.GetTable();
   // skip tokens until it is in the first or is a synch token
   while (!IsComplete() && table[top_symbol][current_token] == std::string(ERROR_TOKEN)) {
+    std::string ret;
+    ret += "Parsing error at symbol : " + current_token + " \n";
+    parser_errors_.push_back(ret);
     DoNextStep();
     if (current_step_ < static_cast<int>(current_string_.size())) {
       current_token = current_string_[current_step_];
@@ -63,6 +74,9 @@ void Parser::ParseNextStep() {
   if (!IsComplete()) {
     // if SYNCH TOKEN - We skip the current symbol on stack top
     if (table[top_symbol][current_token] == std::string(SYNCH_TOKEN)) {
+      std::string ret;
+      ret += "Parsing error at symbol : " + current_token + " \n";
+      parser_errors_.push_back(ret);
       stack_.pop();
     } else {
       // check if current stack top matches the current token
@@ -89,7 +103,5 @@ void Parser::ParseNextStep() {
     }
   }
 }
-
-const std::vector<int> &Parser::GetProductionHistory() { return production_history_; }
 
 }  // namespace jucc::parser

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -56,7 +56,7 @@ void Parser::ParseNextStep() {
   // skip tokens until it is in the first or is a synch token
   while (!IsComplete() && table[top_symbol][current_token] == std::string(ERROR_TOKEN)) {
     std::string ret;
-    ret += "parser: error at symbol : " + current_token + " \n";
+    ret += "parser error: at symbol: " + current_token;
     parser_errors_.push_back(ret);
     DoNextStep();
     if (current_step_ < static_cast<int>(current_string_.size())) {
@@ -67,7 +67,7 @@ void Parser::ParseNextStep() {
     // if SYNCH TOKEN - We skip the current symbol on stack top
     if (table[top_symbol][current_token] == std::string(SYNCH_TOKEN)) {
       std::string ret;
-      ret += "parser: error at symbol : " + current_token + " \n";
+      ret += "parser error: at symbol: " + current_token;
       parser_errors_.push_back(ret);
       stack_.pop();
     } else {

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -50,21 +50,13 @@ void Parser::DoNextStep() {
 }
 
 void Parser::ParseNextStep() {
-  // if there are parsing table errors do not perform parsing
-  if (!parsing_table_errors_.empty()) {
-    if (!parser_errors_.empty()) {
-      return;
-    }
-    parser_errors_ = parsing_table_errors_;
-    return;
-  }
   std::string top_symbol = stack_.top();
   std::string current_token = current_string_[current_step_];
   ParsingTable::Table table = table_.GetTable();
   // skip tokens until it is in the first or is a synch token
   while (!IsComplete() && table[top_symbol][current_token] == std::string(ERROR_TOKEN)) {
     std::string ret;
-    ret += "Parsing error at symbol : " + current_token + " \n";
+    ret += "parser: error at symbol : " + current_token + " \n";
     parser_errors_.push_back(ret);
     DoNextStep();
     if (current_step_ < static_cast<int>(current_string_.size())) {
@@ -75,7 +67,7 @@ void Parser::ParseNextStep() {
     // if SYNCH TOKEN - We skip the current symbol on stack top
     if (table[top_symbol][current_token] == std::string(SYNCH_TOKEN)) {
       std::string ret;
-      ret += "Parsing error at symbol : " + current_token + " \n";
+      ret += "parser: error at symbol : " + current_token + " \n";
       parser_errors_.push_back(ret);
       stack_.pop();
     } else {

--- a/src/parser/parsing_table.cpp
+++ b/src/parser/parsing_table.cpp
@@ -17,6 +17,13 @@ void ParsingTable::BuildTable() {
   for (auto &nt : non_terminals_) {
     if (follows_.count(nt) != 0U) {
       for (const auto &symbol : follows_[nt]) {
+        if (table_[nt][symbol] != std::string(ERROR_TOKEN)) {
+          std::string ret;
+          ret += "Error duplicate entry in parsing table, ";
+          ret += "Production : " + nt;
+          ret += " Symbol : " + symbol;
+          errors_.push_back(ret);
+        }
         table_[nt][symbol] = std::string(SYNCH_TOKEN);
       }
     }
@@ -30,29 +37,47 @@ void ParsingTable::BuildTable() {
 
       // check if first_entity is terminal
       if (std::find(terminals_.begin(), terminals_.end(), first_entity) != terminals_.end()) {
+        std::string entry = table_[productions_[prod_no].GetParent()][first_entity];
+        if ((entry != std::string(ERROR_TOKEN)) && (entry != std::string(SYNCH_TOKEN))) {
+          std::string ret;
+          ret += "Error duplicate entry in parsing table, ";
+          ret += "Production : " + productions_[prod_no].GetParent();
+          ret += " Symbol : " + first_entity;
+          errors_.push_back(ret);
+        }
         table_[productions_[prod_no].GetParent()][first_entity] = std::to_string(prod_no * 100 + rule_no);
       } else if (std::find(non_terminals_.begin(), non_terminals_.end(), first_entity) != non_terminals_.end()) {
         // first entity is a non-terminal
         if (firsts_.count(first_entity) != 0U) {
           for (auto &symbol : firsts_[first_entity]) {
             if (symbol != std::string(grammar::EPSILON)) {
+              std::string entry = table_[productions_[prod_no].GetParent()][symbol];
+              if ((entry != std::string(ERROR_TOKEN)) && (entry != std::string(SYNCH_TOKEN))) {
+                std::string ret;
+                ret += "Error duplicate entry in parsing table, ";
+                ret += "Production : ";
+                ret = ret.append(productions_[prod_no].GetParent());
+                ret += " Symbol : ";
+                ret = ret.append(symbol);
+                errors_.push_back(ret);
+              }
               table_[productions_[prod_no].GetParent()][symbol] = std::to_string(prod_no * 100 + rule_no);
             }
           }
-          // if epsilon present add production under follow(A) symbols
-          if (std::find(firsts_[first_entity].begin(), firsts_[first_entity].end(), std::string(grammar::EPSILON)) !=
-              firsts_[first_entity].end()) {
-            if (follows_.count(productions_[prod_no].GetParent()) != 0U) {
-              for (auto &symbol : follows_[productions_[prod_no].GetParent()]) {
-                table_[productions_[prod_no].GetParent()][symbol] = std::to_string(prod_no * 100 + rule_no);
-              }
-            }
-          }
         }
+
       } else if (first_entity == std::string(grammar::EPSILON)) {
         // first entity is epsilon
         if (follows_.count(productions_[prod_no].GetParent()) != 0U) {
           for (auto &symbol : follows_[productions_[prod_no].GetParent()]) {
+            std::string entry = table_[productions_[prod_no].GetParent()][symbol];
+            if ((entry != std::string(ERROR_TOKEN)) && (entry != std::string(SYNCH_TOKEN))) {
+              std::string ret;
+              ret += "Error duplicate entry in parsing table, ";
+              ret += "Production : " + productions_[prod_no].GetParent();
+              ret += " Symbol : " + symbol;
+              errors_.push_back(ret);
+            }
             table_[productions_[prod_no].GetParent()][symbol] = std::to_string(prod_no * 100 + rule_no);
           }
         }

--- a/src/parser/parsing_table.cpp
+++ b/src/parser/parsing_table.cpp
@@ -5,6 +5,17 @@
 
 namespace jucc::parser {
 
+std::string ParsingTable::GenerateMessage(std::string production, std::string symbol) {
+  std::string ret;
+  ret += "error: duplicate entry in parsing table, ";
+  ret += "production: ";
+  ret = ret.append(production);
+  ret += " symbol: ";
+  ret = ret.append(symbol);
+  ret += "\n";
+  return ret;
+}
+
 void ParsingTable::BuildTable() {
   // fill initially all errors
   for (auto &nt : non_terminals_) {
@@ -18,11 +29,7 @@ void ParsingTable::BuildTable() {
     if (follows_.count(nt) != 0U) {
       for (const auto &symbol : follows_[nt]) {
         if (table_[nt][symbol] != std::string(ERROR_TOKEN)) {
-          std::string ret;
-          ret += "Error duplicate entry in parsing table, ";
-          ret += "Production : " + nt;
-          ret += " Symbol : " + symbol;
-          errors_.push_back(ret);
+          errors_.push_back(GenerateMessage(nt, symbol));
         }
         table_[nt][symbol] = std::string(SYNCH_TOKEN);
       }
@@ -39,11 +46,7 @@ void ParsingTable::BuildTable() {
       if (std::find(terminals_.begin(), terminals_.end(), first_entity) != terminals_.end()) {
         std::string entry = table_[productions_[prod_no].GetParent()][first_entity];
         if ((entry != std::string(ERROR_TOKEN)) && (entry != std::string(SYNCH_TOKEN))) {
-          std::string ret;
-          ret += "Error duplicate entry in parsing table, ";
-          ret += "Production : " + productions_[prod_no].GetParent();
-          ret += " Symbol : " + first_entity;
-          errors_.push_back(ret);
+          errors_.push_back(GenerateMessage(productions_[prod_no].GetParent(), first_entity));
         }
         table_[productions_[prod_no].GetParent()][first_entity] = std::to_string(prod_no * 100 + rule_no);
       } else if (std::find(non_terminals_.begin(), non_terminals_.end(), first_entity) != non_terminals_.end()) {
@@ -53,13 +56,7 @@ void ParsingTable::BuildTable() {
             if (symbol != std::string(grammar::EPSILON)) {
               std::string entry = table_[productions_[prod_no].GetParent()][symbol];
               if ((entry != std::string(ERROR_TOKEN)) && (entry != std::string(SYNCH_TOKEN))) {
-                std::string ret;
-                ret += "Error duplicate entry in parsing table, ";
-                ret += "Production : ";
-                ret = ret.append(productions_[prod_no].GetParent());
-                ret += " Symbol : ";
-                ret = ret.append(symbol);
-                errors_.push_back(ret);
+                errors_.push_back(GenerateMessage(productions_[prod_no].GetParent(), symbol));
               }
               table_[productions_[prod_no].GetParent()][symbol] = std::to_string(prod_no * 100 + rule_no);
             }
@@ -72,11 +69,7 @@ void ParsingTable::BuildTable() {
           for (auto &symbol : follows_[productions_[prod_no].GetParent()]) {
             std::string entry = table_[productions_[prod_no].GetParent()][symbol];
             if ((entry != std::string(ERROR_TOKEN)) && (entry != std::string(SYNCH_TOKEN))) {
-              std::string ret;
-              ret += "Error duplicate entry in parsing table, ";
-              ret += "Production : " + productions_[prod_no].GetParent();
-              ret += " Symbol : " + symbol;
-              errors_.push_back(ret);
+              errors_.push_back(GenerateMessage(productions_[prod_no].GetParent(), symbol));
             }
             table_[productions_[prod_no].GetParent()][symbol] = std::to_string(prod_no * 100 + rule_no);
           }

--- a/src/parser/parsing_table.cpp
+++ b/src/parser/parsing_table.cpp
@@ -5,7 +5,7 @@
 
 namespace jucc::parser {
 
-std::string ParsingTable::GenerateMessage(std::string production, std::string symbol) {
+std::string ParsingTable::GenerateMessage(const std::string &production, const std::string &symbol) {
   std::string ret;
   ret += "error: duplicate entry in parsing table, ";
   ret += "production: ";

--- a/test/parser/parser_test.cpp
+++ b/test/parser/parser_test.cpp
@@ -62,7 +62,10 @@ TEST(parser, Parser1) {
   pars.ParseNextStep();
 
   std::vector<int> history;
+  std::vector<std::string> parser_errors;
   history = pars.GetProductionHistory();
+  parser_errors = pars.GetParserErrors();
+  ASSERT_EQ(parser_errors.size(), 1);
   // Stack - T E' $
   ASSERT_EQ(history.size(), 1);
   ASSERT_EQ(history[0], 0);
@@ -98,6 +101,9 @@ TEST(parser, Parser1) {
   // Stack - F T' E' $
   pars.ParseNextStep();
   history = pars.GetProductionHistory();
+
+  parser_errors = pars.GetParserErrors();
+  ASSERT_EQ(parser_errors.size(), 2);
 
   // Stack - T' E' $
   pars.ParseNextStep();

--- a/test/parser/parsing_table_test.cpp
+++ b/test/parser/parsing_table_test.cpp
@@ -42,8 +42,7 @@ TEST(parser, ParsingTable1) {
   table.SetProductions(grammar);
   table.BuildTable();
 
-  std::vector<std::string> tl;
-  ASSERT_EQ(table.GetErrors(), tl);
+  ASSERT_EQ(table.GetErrors().size(), 0);
 
   std::pair<int, int> p;
   p = table.GetEntry("S", "a");
@@ -104,8 +103,7 @@ TEST(parser, ParsingTable2) {
   table.SetProductions(grammar);
   table.BuildTable();
 
-  std::vector<std::string> tl;
-  ASSERT_EQ(table.GetErrors(), tl);
+  ASSERT_EQ(table.GetErrors().size(), 0);
 
   std::pair<int, int> p;
   p = table.GetEntry("S", "a");
@@ -166,8 +164,7 @@ TEST(parser, ParsingTable3) {
   table.SetProductions(grammar);
   table.BuildTable();
 
-  std::vector<std::string> tl;
-  ASSERT_EQ(table.GetErrors(), tl);
+  ASSERT_EQ(table.GetErrors().size(), 0);
 
   std::pair<int, int> p;
   p = table.GetEntry("S", "a");
@@ -228,8 +225,7 @@ TEST(parser, ParsingTable4) {
   table.SetProductions(grammar);
   table.BuildTable();
 
-  std::vector<std::string> tl;
-  ASSERT_EQ(table.GetErrors(), tl);
+  ASSERT_EQ(table.GetErrors().size(), 0);
 
   std::pair<int, int> p;
   p = table.GetEntry("S", "a");
@@ -331,7 +327,7 @@ TEST(parser, ParsingTable6) {
   table.SetProductions(grammar);
   table.BuildTable();
 
-  ASSERT_GT(table.GetErrors().size(), 0);
+  ASSERT_EQ(table.GetErrors().size(), 2);
 }
 
 TEST(parser, ParsingTable7) {
@@ -364,5 +360,5 @@ TEST(parser, ParsingTable7) {
   table.SetProductions(grammar);
   table.BuildTable();
 
-  ASSERT_GT(table.GetErrors().size(), 0);
+  ASSERT_EQ(table.GetErrors().size(), 1);
 }

--- a/test/parser/parsing_table_test.cpp
+++ b/test/parser/parsing_table_test.cpp
@@ -333,3 +333,36 @@ TEST(parser, ParsingTable6) {
 
   ASSERT_GT(table.GetErrors().size(), 0);
 }
+
+TEST(parser, ParsingTable7) {
+  /**
+   * Test: Context Free Grammar
+   * S : A | A
+   * A : a
+   *
+   * Not LL1 grammar
+   */
+  grammar::Production p1;
+  p1.SetParent("S");
+  p1.SetRules({grammar::Rule({"A"}), grammar::Rule({"A"})});
+  grammar::Production p2;
+  p2.SetParent("A");
+  p2.SetRules({grammar::Rule({"a"})});
+
+  grammar::Productions grammar = {p1, p2};
+
+  auto nullables = utils::CalcNullables(grammar);
+  auto firsts = utils::CalcFirsts(grammar, nullables);
+  auto follows = utils::CalcFollows(grammar, firsts, nullables, "S");
+
+  std::vector<std::string> terminals = {"a"};
+  std::vector<std::string> non_terminals = {"A", "S"};
+
+  ParsingTable table = ParsingTable(terminals, non_terminals);
+  table.SetFirsts(firsts);
+  table.SetFollows(follows);
+  table.SetProductions(grammar);
+  table.BuildTable();
+
+  ASSERT_GT(table.GetErrors().size(), 0);
+}

--- a/test/parser/parsing_table_test.cpp
+++ b/test/parser/parsing_table_test.cpp
@@ -1,7 +1,5 @@
 #include "parser/parsing_table.h"
 
-#include <iostream>
-
 #include "grammar/grammar.h"
 #include "gtest/gtest.h"
 


### PR DESCRIPTION
# Parsing and Parsing Table Error Detection.
Fixes Error Detection problem in construction of ll1 parsing table and the parser.

Errors are now detected in case of non-LL(1) grammar and the input is not parsed until the grammar provided is LL(1).

Checklist

- [X] Add error statements in Parser class
- [X] Add error detection in ParsingTable class
- [X] Make sure incorrect grammar file or input file doesn't cause segmentation faults.



Fixes #26 


